### PR TITLE
Inclusion of new tests to support the mef_eline's scheduler verification process

### DIFF
--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -318,18 +318,19 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_patch_start_date(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        start_delay = 60
+        start_delay = 20
         ts1 = datetime.now() + timedelta(seconds=start_delay)
 
         payload = {
             "name": "my evc1",
-            "enabled": False,
+            "enabled": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             },
+            # ToDo this attribute should be start_date
             "request_time": ts1.strftime(TIME_FMT)
         }
 
@@ -337,7 +338,7 @@ class TestE2EMefEline:
         data = response.json()
         circuit_id = data['circuit_id']
 
-        time.sleep(50)
+        time.sleep(10)
 
         # It verifies EVC's data
         response = requests.get(api_url + circuit_id)
@@ -348,19 +349,28 @@ class TestE2EMefEline:
         ts2 = ts1 + timedelta(seconds=start_delay)
 
         payload2 = {
-            "start_date": ts2.strftime(TIME_FMT)
+            # ToDo this attribute should be start_date
+            "request_time": ts2.strftime(TIME_FMT)
         }
 
         # create circuit schedule
         response = requests.patch(api_url + circuit_id, json=payload2)
         assert response.status_code == 200
 
-        time.sleep(90)
+        time.sleep(20)
 
         # It verifies EVC's data
         response = requests.get(api_url + circuit_id)
         data = response.json()
-        assert data['start_date'] == ts2.strftime(TIME_FMT)
+        assert data['active'] is False
+
+        time.sleep(20)
+
+        # It verifies EVC's data
+        response = requests.get(api_url + circuit_id)
+        data = response.json()
+        # ToDo this attribute should be start_date
+        assert data['request_time'] == ts2.strftime(TIME_FMT)
         assert data['active'] is True
 
     def test_delete_circuit_id(self, circuit_id):


### PR DESCRIPTION
## Description of the Change
This new bach includes some tests to support the mef_eline's scheduler verification process, such as:

1. New modifications to verify the circuit patching process behavior and outcome
2. New tests to support the verification relative to performance behavior over execution failures, such as:
- Schedule's creation given an invalid JSON
- Schedule's creation given an empty JSON
- Schedule's creation in a deleted circuit
- Schedule's creation in an unknown circuit

- Schedule's modification given an invalid JSON
- Schedule's modification given an empty JSON
- Schedule's modification given a deleted schedule's id information
- Schedule's modification in a deleted circuit
- Schedule's modification given an unknown schedule's id information

- Schedule's removal action on a deleted circuit
- Schedule's removal given an unknown schedule's id information
- Schedule's removal action on a deleted schedule

## Release Notes
N/A