### PR TITLE
Update sdntrace_cp tests according to changes on sdntrace PR 62

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -265,8 +265,8 @@ class TestE2ESDNTrace:
         api_url = KYTOS_API + '/amlight/sdntrace_cp/trace'
         response = requests.put(api_url, json=payload_1)
         data = response.json()
-        # only 5 steps are expected: starting, 1->2, 2->3, 3->4, 4->5
-        assert len(data["result"]) == 5, data
+        # only 4 steps are expected: starting, 1->2, 2->3, 3->4
+        assert len(data["result"]) == 4, str(data)
 
         full_path = [
             (
@@ -283,7 +283,7 @@ class TestE2ESDNTrace:
         ]
 
         assert full_path != actual, f"Full path {full_path}. Actual: {actual}"
-        assert full_path[:4] == actual, f"Expected {full_path[:4]}. Actual: {actual}"
+        assert full_path[:3] == actual, f"Expected {full_path[:4]}. Actual: {actual}"
 
         # 3. sdntrace data plane - Trace from UNI_A
         payload_2 = {


### PR DESCRIPTION
This PR is related to PR kytos-ng/sdntrace_cp#62

### Description of the change

This PR updates the end-to-end tests to reflect the changes on sdntrace PR kytos-ng/sdntrace_cp#62.

Without this PR:

```
rerun: 0
tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_020_run_sdntrace_fail_missing_flow: 2023-01-23,15:29:48.887661 - 2023-01-23,15:29:58.930211
self = <tests.test_e2e_40_sdntrace.TestE2ESDNTrace object at 0x7f589e14f7c0>

    def test_020_run_sdntrace_fail_missing_flow(self):
..
        # only 5 steps are expected: starting, 1->2, 2->3, 3->4, 4->5
>       assert len(data["result"]) == 5, data
E       AssertionError: {'result': [{'dpid': '00:00:00:00:00:00:00:01', 'port': 1, 'time': '2023-01-23 15:29:58.927728', 'type': 'starting', ....pid': '00:00:00:00:00:00:00:04', 'out': {'port': 3, 'vlan': 1}, 'port': 2, 'time': '2023-01-23 15:29:58.927846', ...}]}
E       assert 4 == 5
E        +  where 4 = len([{'dpid': '00:00:00:00:00:00:00:01', 'port': 1, 'time': '2023-01-23 15:29:58.927728', 'type': 'starting', ...}, {'dpid...dpid': '00:00:00:00:00:00:00:04', 'out': {'port': 3, 'vlan': 1}, 'port': 2, 'time': '2023-01-23 15:29:58.927846', ...}])

tests/test_e2e_40_sdntrace.py:269: AssertionError


## and


rerun: 0
tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_020_run_sdntrace_fail_missing_flow: 2023-01-23,16:49:18.553829 - 2023-01-23,16:49:28.623810
self = <tests.test_e2e_40_sdntrace.TestE2ESDNTrace object at 0x7f72ec5fecd0>

    def test_020_run_sdntrace_fail_missing_flow(self):
...
        actual = [
            (step['dpid'], step['port'], step['vlan'])
            for step in data["result"][1:]
        ]

        assert full_path != actual, f"Full path {full_path}. Actual: {actual}"
>       assert full_path[:4] == actual, f"Expected {full_path[:4]}. Actual: {actual}"
E       AssertionError: Expected [('00:00:00:00:00:00:00:02', 2, 1), ('00:00:00:00:00:00:00:03', 2, 1), ('00:00:00:00:00:00:00:04', 2, 1), ('00:00:00:00:00:00:00:05', 2, 1)]. Actual: [('00:00:00:00:00:00:00:02', 2, 1), ('00:00:00:00:00:00:00:03', 2, 1), ('00:00:00:00:00:00:00:04', 2, 1)]
E       assert [('00:00:00:0...00:05', 2, 1)] == [('00:00:00:0...00:04', 2, 1)]
E         Left contains one more item: ('00:00:00:00:00:00:00:05', 2, 1)
E         Use -v to get more diff

tests/test_e2e_40_sdntrace.py:286: AssertionError
```

After the changes:

```
+ python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_020_run_sdntrace_fail_missing_flow --reruns 0 -r fEr
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0
collected 1 item

tests/test_e2e_40_sdntrace.py .                                                                                                                                                                                                     [100%]

============================================================================================================ warnings summary =============================================================================================================
------------------------------------------------------------------------------------------------------------ start/stop times -------------------------------------------------------------------------------------------------------------
=============================================================================================== 1 passed, 98 warnings in 100.93s (0:01:40) ================================================================================================
```