### PR TITLE
Updated tests from mef_eline

### DIFF
--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -106,6 +106,43 @@ class TestE2EMefEline:
         data = response.json()
         return data
 
+    def test_002_update_uni(self):
+        """Test when a uni is updated"""
+        api_url = KYTOS_API + "/mef_eline/v2/evc/"
+        evc_id = self.create_evc(
+            uni_a="00:00:00:00:00:00:00:01:1",
+            uni_z="00:00:00:00:00:00:00:03:1",
+            vlan_id=100,
+        )
+        time.sleep(10)
+        response = requests.get(api_url + evc_id)
+        data = response.json()
+        assert data["enabled"]
+        assert data["active"]
+
+        # Update the EVC switching the uni_z to switch 2
+        self.update_evc(
+            evc_id,
+            uni_z={
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {"tag_type": 1, "value": 100}
+            },
+        )
+        time.sleep(10)
+        response = requests.get(api_url + evc_id)
+        data = response.json()
+        assert data["uni_z"]["interface_id"] == "00:00:00:00:00:00:00:02:1"
+
+        h11, h2 = self.net.net.get('h11', 'h2')
+        h11.cmd('ip link add link %s name vlan100 type vlan id 100' % (h11.intfNames()[0]))
+        h11.cmd('ip link set up vlan100')
+        h11.cmd('ip addr add 100.0.0.11/24 dev vlan100')
+        h2.cmd('ip link add link %s name vlan100 type vlan id 100' % (h2.intfNames()[0]))
+        h2.cmd('ip link set up vlan100')
+        h2.cmd('ip addr add 100.0.0.2/24 dev vlan100')
+        result = h11.cmd('ping -c1 100.0.0.2')
+        assert ', 0% packet loss,' in result
+
     def test_001_create_update_with_constraints(self):
         """Test to create -> update with constraints."""
 
@@ -151,29 +188,6 @@ class TestE2EMefEline:
         assert current_path_ids == red_link_ids, current_path_ids
         assert failover_path_ids == blue_link_ids, failover_path_ids
 
-        # Update the EVC switching the uni_z to switch 2
-        self.update_evc(
-            evc_id,
-            uni_z={
-                "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
-            },
-        )
-        time.sleep(10)
-        response = requests.get(api_url + evc_id)
-        data = response.json()
-        assert data["uni_z"]["interface_id"] == "00:00:00:00:00:00:00:02:1"
-
-        h11, h2 = self.net.net.get('h11', 'h2')
-        h11.cmd('ip link add link %s name vlan100 type vlan id 100' % (h11.intfNames()[0]))
-        h11.cmd('ip link set up vlan100')
-        h11.cmd('ip addr add 100.0.0.11/24 dev vlan100')
-        h2.cmd('ip link add link %s name vlan100 type vlan id 100' % (h2.intfNames()[0]))
-        h2.cmd('ip link set up vlan100')
-        h2.cmd('ip addr add 100.0.0.2/24 dev vlan100')
-        result = h11.cmd('ping -c1 100.0.0.2')
-        assert ', 0% packet loss,' in result
-
         # update the EVC switching the primary and secondary constraints
         self.update_evc(
             evc_id,
@@ -184,10 +198,6 @@ class TestE2EMefEline:
             secondary_constraints={
                 "mandatory_metrics": {"ownership": "red"},
                 "spf_attribute": "hop",
-            },
-            uni_z={
-                "interface_id": "00:00:00:00:00:00:00:03:1",
-                "tag": {"tag_type": 1, "value": 100}
             },
         )
         time.sleep(10)


### PR DESCRIPTION
Related to issue from `mef_eline` [#249](https://github.com/kytos-ng/mef_eline/issues/249)

### Summary
Changed test `test_001_create_update_with_constraints()` from `test_e2e_15_mef_eline.py` to comply with changes made on `mef_eline` PR [#254](https://github.com/kytos-ng/mef_eline/pull/254)

### Tests
```
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_15_mef_eline.py .                                         [100%]
```