### PR TITLE
test: added test_016_install_invalid_flow_cookie_overflowed

### DIFF
--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -203,6 +203,32 @@ class TestE2EFlowManager:
             assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS + 1, flows_sw
             assert 'actions=output:"%s-eth2"' % sw_name in flows_sw
 
+    def test_016_install_invalid_flow_cookie_overflowed(self):
+        """Test try to install an overflowed cookie value."""
+        payload = {
+          "flows": [
+            {
+              "priority": 101,
+              "cookie": 27115650311270694912,
+              "match": {
+                "in_port": 1
+              },
+              "actions": [
+                {
+                  "action_type": "output",
+                  "port": 2
+                }
+              ]
+            }
+          ]
+        }
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400, response.text
+        data = response.json()
+        assert "FlowMod.cookie" in data["description"]
+
     def test_020_delete_flow(self):
         """Tests if, after kytos restart, a flow deleted
         from a switch will still be deleted."""


### PR DESCRIPTION
Closes #205 

Related to https://github.com/kytos-ng/of_core/issues/102

### Summary

Added `test_016_install_invalid_flow_cookie_overflowed`. `flow_manager` still hasn't complete implemented API spec validation, but this was a case where it ended hitting a problem in `msg_out` queue so we're adding this as a regression test. In the future, more validation tests should be planned for
 
### Local Tests

This individual test is passing building with the branches that it depends on https://github.com/kytos-ng/flow_manager/pull/137

```
+ python3 -m pytest tests/ --timeout=600 -k test_016_install_invalid_flow_cookie_overflowed
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
timeout: 600.0s
timeout method: signal
timeout func_only: False
collected 206 items / 205 deselected / 1 selected

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
```

