### PR TITLE
fix: update for change in the response of /traces

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -383,7 +383,7 @@ class TestE2ESDNTrace:
                     {
                         "trace": {
                             "switch": {
-                                "dpid": "00:00:00:00:00:00:00:01",
+                                "dpid": "00:00:00:00:00:00:00:02",
                                 "in_port": 1
                             },
                             "eth": {
@@ -395,7 +395,7 @@ class TestE2ESDNTrace:
                         "trace": {
                             "switch": {
                                 "dpid": "00:00:00:00:00:00:00:01",
-                                "in_port": 2
+                                "in_port": 1
                             },
                             "eth": {
                                 "dl_vlan": 101
@@ -416,4 +416,13 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data["result"]) == 3
+        list_results = data["result"] 
+        assert len(list_results) == 3
+
+        assert list_results[0] == []
+
+        assert list_results[1][0]["dpid"] == "00:00:00:00:00:00:00:01"
+        assert list_results[1][0]["port"] == 1
+
+        assert list_results[2] == []
+

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -409,14 +409,6 @@ class TestE2ESDNTrace:
                                 "in_port": 1
                             }
                         }
-                    },
-                    {
-                        "trace": {
-                            "switch": {
-                                "dpid": "00:00:00:00:00:00:00:0a",
-                                "in_port": 1
-                            }
-                        }
                     }
                 ]
                 
@@ -424,8 +416,4 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 2
-        assert "00:00:00:00:00:00:00:01" in data
-        assert len(data["00:00:00:00:00:00:00:01"]) == 2
-        assert "00:00:00:00:00:00:00:0a" in data
-        assert len(data["00:00:00:00:00:00:00:0a"]) == 1
+        assert len(data["result"]) == 3

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -377,7 +377,7 @@ class TestE2ESDNTrace:
     def test_030_run_sdntrace_for_stored_flows(cls):
         """Run SDNTrace to get traces from flow_manager stored_flow"""
         cls.create_evc(100, "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:0a:1")
-        cls.create_evc(101, "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:0a:1")
+        cls.create_evc(101, "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:0a:1")
         cls.create_evc(102, "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:0a:1")
         payload = [
                     {
@@ -398,7 +398,7 @@ class TestE2ESDNTrace:
                                 "in_port": 1
                             },
                             "eth": {
-                                "dl_vlan": 101
+                                "dl_vlan": 100
                             }
                         }
                     },
@@ -409,6 +409,17 @@ class TestE2ESDNTrace:
                                 "in_port": 1
                             }
                         }
+                    },
+                    {
+                        "trace": {
+                            "switch": {
+                                "dpid": "00:00:00:00:00:00:00:03",
+                                "in_port": 2
+                            },
+                            "eth": {
+                                "dl_vlan": 101
+                            }
+                        }
                     }
                 ]
                 
@@ -417,12 +428,17 @@ class TestE2ESDNTrace:
         assert response.status_code == 200, response.text
         data = response.json()
         list_results = data["result"] 
-        assert len(list_results) == 3
+
+        assert len(list_results) == 4
 
         assert list_results[0] == []
 
+        assert len(list_results[1]) == 10
         assert list_results[1][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert list_results[1][0]["port"] == 1
 
         assert list_results[2] == []
 
+        assert len(list_results[3]) == 8
+        assert list_results[3][0]["dpid"] == "00:00:00:00:00:00:00:03"
+        assert list_results[3][0]["port"] == 2


### PR DESCRIPTION
This is related to PR https://github.com/kytos-ng/sdntrace_cp/pull/75.

### Summary

`test_030_run_sdntrace_for_stored_flows` has been updated, as the response of `/traces` has been changed.

The response is verified to be a list with the same number of elements as the number of requests.
In addition, some cases are checked in which the response must be an empty list and a case in which a complete trace must be returned.

### Local Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 4 items

tests/test_e2e_40_sdntrace.py ....                                       [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 4 passed, 98 warnings in 143.75s (0:02:23) ==================

### End-to-End Tests

N/A