### PR TITLE
feat: Update tests to use vlan as string instead of int

### DIFF
--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -367,7 +367,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000001,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 100
+                        "dl_vlan": "100"
                     },
                     "actions": [
                         {
@@ -380,7 +380,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000002,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 101
+                        "dl_vlan": "101"
                     },
                     "actions": [
                         {
@@ -463,7 +463,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000001,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 100
+                        "dl_vlan": "100"
                     },
                     "actions": [
                         {
@@ -476,7 +476,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000002,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 101
+                        "dl_vlan": "101"
                     },
                     "actions": [
                         {
@@ -489,7 +489,7 @@ class TestE2EFlowManager:
                     "cookie": 0xbb00000000000001,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 102
+                        "dl_vlan": "102"
                     },
                     "actions": [
                         {
@@ -560,7 +560,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000001,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 100
+                        "dl_vlan": "100"
                     },
                     "actions": [
                         {
@@ -573,7 +573,7 @@ class TestE2EFlowManager:
                     "cookie": 0xaa00000000000002,
                     "match": {
                         "in_port": 1,
-                        "dl_vlan": 101
+                        "dl_vlan": "101"
                     },
                     "actions": [
                         {


### PR DESCRIPTION
When PR kytos-ng/flow_manager#135 arrives the flows will have `dl_vlan` stored as strings, so the tests need to compare the stored flows `dl_vlan` with strings.

PS: This PR should be merge with  kytos-ng/flow_manager#135