### PR TITLE
feature: Added a test to check that the order of the requested stored flows is descending

### DIFF
--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -237,7 +237,8 @@ class TestE2EFlowManager:
         payload = {
             "flows": [
                 {
-                    "priority": 30,
+                    "cookie": 1,
+                    "priority": 1,
                     "match": {
                         "in_port": 1
                     },
@@ -249,6 +250,7 @@ class TestE2EFlowManager:
                     ]
                 },
                 {
+                    "cookie": 2,
                     "priority": 10,
                     "match": {
                         "in_port": 1
@@ -261,6 +263,7 @@ class TestE2EFlowManager:
                     ]
                 },
                 {
+                    "cookie": 3,
                     "priority": 20,
                     "match": {
                         "in_port": 2
@@ -289,13 +292,13 @@ class TestE2EFlowManager:
 
         time.sleep(10)
 
-        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}'
+        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}&cookie_range=1&cookie_range=3'
         response = requests.get(stored_flows)
         assert response.status_code == 200, response.text
         data = response.json()
         data = data[switch_id]
-        assert data[BASIC_FLOWS]["flow"]["priority"] > data[BASIC_FLOWS+1]["flow"]["priority"] 
-        assert data[BASIC_FLOWS+1]["flow"]["priority"] > data[BASIC_FLOWS+2]["flow"]["priority"] 
+        assert data[0]["flow"]["priority"] > data[1]["flow"]["priority"] 
+        assert data[1]["flow"]["priority"] > data[2]["flow"]["priority"]
 
     def test_020_delete_flow(self):
         """Tests if, after kytos restart, a flow deleted

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -229,6 +229,74 @@ class TestE2EFlowManager:
         data = response.json()
         assert "FlowMod.cookie" in data["description"]
 
+    def test_017_install_flows_and_retrieve_sorted(self):
+        """Test that flows are returned in order according to priority."""
+
+        switch_id = '00:00:00:00:00:00:00:01'
+
+        payload = {
+            "flows": [
+                {
+                    "priority": 30,
+                    "match": {
+                        "in_port": 1
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 3
+                        }
+                    ]
+                },
+                {
+                    "priority": 10,
+                    "match": {
+                        "in_port": 1
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
+                },
+                {
+                    "priority": 20,
+                    "match": {
+                        "in_port": 2
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # It installs the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_id
+        requests.post(api_url, data=json.dumps(payload),
+                      headers={'Content-type': 'application/json'})
+
+        # wait for the flow to be installed
+        time.sleep(10)
+
+        # restart controller keeping configuration
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
+
+        time.sleep(10)
+
+        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}'
+        response = requests.get(stored_flows)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        data = data[switch_id]
+        assert data[BASIC_FLOWS]["flow"]["priority"] > data[BASIC_FLOWS+1]["flow"]["priority"] 
+        assert data[BASIC_FLOWS+1]["flow"]["priority"] > data[BASIC_FLOWS+2]["flow"]["priority"] 
+
     def test_020_delete_flow(self):
         """Tests if, after kytos restart, a flow deleted
         from a switch will still be deleted."""


### PR DESCRIPTION
Related to a PR in [flow_manager](https://github.com/kytos-ng/flow_manager/pull/140)

### Summary

Add a test to check that `/flow_manager/v2/stored_flows` returns flows that are sorted in descending order by `priority`. 

### Local Tests

+ python3 -m pytest tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_017_install_flows_and_retrieve_sorted
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
test_e2e_20_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_20_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 143.86s (0:02:23) ==================

### End-to-End Tests

N/A