### PR TITLE
Test new cases of loop in /traces

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -770,6 +770,5 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
-        list_results = data["result"] 
-        print(list_results)
+        list_results = data["result"]
         assert list_results[0][0]["out"]["port"] == 1


### PR DESCRIPTION
Related to [PR 81 in sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/pull/81)

### Summary

Add `tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_055_run_sdntrace_loop` to check that a loop is detected when the input and outgoing interfaces match in a trace.

### Local Tests

tests/test_e2e_40_sdntrace.py ........                                   [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 8 passed, 98 warnings in 246.68s (0:04:06) ==================

### End-to-End Tests

N/A