### PR TITLE
Test `untagged` and `any` values for vlan in sdntrace_cp

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -886,7 +886,7 @@ class TestE2ESDNTrace:
         payload_stored_flow = {
             "flows": [
                 {
-                    "priority": 100,
+                    "priority": 1000,
                     "match": {
                         "in_port": 2,
                         "dl_vlan": "4096/4096"
@@ -899,7 +899,7 @@ class TestE2ESDNTrace:
                     ]
                 },
                 {
-                    "priority": 10,
+                    "priority": 100,
                     "match": {
                         "in_port": 2,
                         "dl_vlan": 10


### PR DESCRIPTION
Related to [PR of `sdntrace_cp`](https://github.com/kytos-ng/sdntrace_cp/pull/82)

### Summary

Add `test_070_run_sdntrace_untagged_vlan` and `test_075_run_sdntrace_any_vlan` to test the `untagged` and `any` cases for `vlan` in `sdntrace_cp`.

### Local Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 10 items

tests/test_e2e_40_sdntrace.py ..........                                 [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================= 10 passed, 98 warnings in 278.75s (0:04:38) ==================

### End-to-End Tests

N/A