### PR TITLE
test: Added test_026_validate_bad_request_response_format

### DIFF
--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -344,4 +344,5 @@ class TestE2EMefEline:
         assert data["code"] == 400
         assert data["name"] == "Bad Request"
         assert "The request body contains invalid API data" in data["description"]
-        assert "1 is not of type 'string' for field uni_a/interface_id." in data["description"]
+        assert "not of type" in data["description"]
+        assert "for field uni_a/interface_id" in data["description"]

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -317,3 +317,31 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
+
+        data = response.json()
+        expected_desc = "Additional properties are not allowed ('active' was unexpected)"
+        assert data["code"] == 400
+        assert data["name"] == "Bad Request"
+        assert expected_desc in data["description"]
+
+    def test_026_validate_bad_request_response_format(self):
+        """Test bad request response shape format."""
+        payload = {
+            "name": "epl",
+            "dynamic_backup_path": True,
+            "uni_a": {
+                "interface_id": 1
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1"
+            }
+        }
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert response.status_code == 400, response.text
+
+        data = response.json()
+        assert data["code"] == 400
+        assert data["name"] == "Bad Request"
+        assert "The request body contains invalid API data" in data["description"]
+        assert "1 is not of type 'string' for field uni_a/interface_id." in data["description"]


### PR DESCRIPTION
Closes #217 

### Summary

Added and augmented test to cover bad request response format since `@validate` decorator implementation will change and is being moved.

### Local Tests

```
+ python3 -m pytest tests/ -k test_025_should_fail_due_to_invalid_attribute_on_payload
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 224 items / 223 deselected / 1 selected

tests/test_e2e_11_mef_eline.py .                                         [100%]

------------------------------- start/stop times -------------------------------
========== 1 passed, 223 deselected, 51 warnings in 79.56s (0:01:19) ===========


+ python3 -m pytest tests/ -k test_026_validate_bad_request_response_format
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 224 items / 223 deselected / 1 selected

tests/test_e2e_11_mef_eline.py .                                         [100%]

========== 1 passed, 223 deselected, 51 warnings in 76.04s (0:01:16) ===========
```


### End-to-End Tests

No need to rerun the entire suite, local tests were run covering the changes. 