### PR TITLE
Test `untagged` and `any` values for `vlan` in `mef_eline`

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1998,27 +1998,3 @@ class TestE2EMefEline:
         data = response.json()
         assert "test" in data[evc_1_id]["metadata"]
         assert "test" in data[evc_2_id]["metadata"]
-
-    def test_250_run_bulk_sdntraces_any_vlan(self):
-        """Test /traces for special dl_vlan"""
-        evc_id = self.create_evc("any")
-        time.sleep(10)
-
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        response = requests.get(api_url + evc_id)
-        assert response.status_code == 200, response.text
-        data = response.json()
-        # path found
-        assert len(data['current_path']) > 0
-
-    def test_255_run_bulk_sdntraces_untagged_vlan(self):
-        """Test /traces for special dl_vlan"""
-        evc_id = self.create_evc("untagged")
-        time.sleep(10)
-
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        response = requests.get(api_url + evc_id)
-        assert response.status_code == 200, response.text
-        data = response.json()
-        # path found
-        assert len(data['current_path']) > 0

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1941,3 +1941,28 @@ class TestE2EMefEline:
         assert untagged_flow["match"] == expected[1]["match"]
         assert untagged_flow["priority"] == expected[1]["priority"]
         assert untagged_flow["instructions"][0]["actions"] == expected[1]["actions"]
+
+    def test_250_run_bulk_sdntraces_any_vlan(self):
+        """Test /traces for special dl_vlan"""
+        evc_id = self.create_evc("any")
+        time.sleep(10)
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        response = requests.get(api_url + evc_id)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        # path found
+        assert len(data['current_path']) > 0
+
+    def test_255_run_bulk_sdntraces_untagged_vlan(self):
+        """Test /traces for special dl_vlan"""
+        evc_id = self.create_evc("untagged")
+        time.sleep(10)
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        response = requests.get(api_url + evc_id)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        # path found
+        assert len(data['current_path']) > 0
+

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -783,9 +783,6 @@ class TestE2ESDNTrace:
                             "switch": {
                                 "dpid": "00:00:00:00:00:00:00:01",
                                 "in_port": 1
-                            },
-                            "eth": {
-                                "dl_vlan": 0
                             }
                         }
                     }
@@ -825,7 +822,7 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
-        list_results = data["result"] 
+        list_results = data["result"]
 
         assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert list_results[0][0]["port"] == 1

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -886,7 +886,7 @@ class TestE2ESDNTrace:
         payload_stored_flow = {
             "flows": [
                 {
-                    "priority": 100,
+                    "priority": 1000,
                     "match": {
                         "in_port": 2,
                         "dl_vlan": "4096/4096"
@@ -899,7 +899,7 @@ class TestE2ESDNTrace:
                     ]
                 },
                 {
-                    "priority": 10,
+                    "priority": 100,
                     "match": {
                         "in_port": 2,
                         "dl_vlan": 10


### PR DESCRIPTION
Related to [PR of `mef_eline`](https://github.com/kytos-ng/mef_eline/pull/303)

### Summary

Add `test_250_run_bulk_sdntraces_any_vlan` and `test_255_run_bulk_sdntraces_untagged_vlan` to test the `untagged` and `any` cases for `vlan` in `mef_eline`.

### Local Tests

```
+ python3 -m pytest tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_250_run_bulk_sdntraces_any_vlan
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_10_mef_eline.py .                                         [100%]

=============================== warnings summary ===============================
test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 131.64s (0:02:11) ==================
```

```
+ python3 -m pytest tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_255_run_bulk_sdntraces_untagged_vlan
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_10_mef_eline.py .                                         [100%]

=============================== warnings summary ===============================
test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 142.28s (0:02:22) ==================
```

### End-to-End Tests

N/A
