### PR TITLE
 `/traces` validates payload

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -843,7 +843,7 @@ class TestE2ESDNTrace:
                             }
                         }
                     }               ]
-                
+
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
@@ -851,7 +851,7 @@ class TestE2ESDNTrace:
         # Wrong data type (dpid should be string):
         payload[0]['trace']['switch']['in_port'] = 3
         payload[0]['trace']['switch']['dpid'] = 1
-                
+
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
@@ -864,9 +864,9 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-        # dl_vlan out of range (should be in [1, 4096¡5]):
+        # dl_vlan out of range (should be in [1, 4095]):
         payload[0]['trace']['eth']['dl_vlan'] = 4096
-                
+
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
@@ -874,14 +874,14 @@ class TestE2ESDNTrace:
         # Wrong dl_type (should be integer):
         payload[0]['trace']['eth']['dl_vlan'] = 10
         payload[0]['trace']['eth']['dl_type'] = "1"
-                
+
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
  
         # Valid request:
         payload[0]['trace']['eth']['dl_type'] = 1
-                
+
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -831,7 +831,7 @@ class TestE2ESDNTrace:
     def test_080_validate_attribute_on_payload(self):
         "Validate parameters"
 
-        # Mandatory parameter missing:
+        # Mandatory parameter missing (in_port):
         payload = [
                     {
                         "trace": {
@@ -848,39 +848,40 @@ class TestE2ESDNTrace:
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-        # Wrong data type:
-        payload = [
-                    {
-                        "trace": {
-                            "switch": {
-                                "dpid": 1,
-                                "in_port": 3
-                            },
-                            "eth": {
-                                "dl_vlan": 10
-                            }
-                        }
-                    }               ]
+        # Wrong data type (dpid should be string):
+        payload[0]['trace']['switch']['in_port'] = 3
+        payload[0]['trace']['switch']['dpid'] = 1
                 
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
 
-        # Wrong dl_vlan:
-        payload = [
-                    {
-                        "trace": {
-                            "switch": {
-                                "dpid": "00:00:00:00:00:00:00:01",
-                                "in_port": 3
-                            },
-                            "eth": {
-                                "dl_vlan": "10"
-                            }
-                        }
-                    }               ]
+        # Wrong dl_vlan (should be integer):
+        payload[0]['trace']['switch']['dpid'] = "00:00:00:00:00:00:00:01"
+        payload[0]['trace']['eth']['dl_vlan'] = "10"
+
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+        # dl_vlan out of range (should be in [1, 4096¡5]):
+        payload[0]['trace']['eth']['dl_vlan'] = 4096
                 
         api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 400, response.text
  
+        # Wrong dl_type (should be integer):
+        payload[0]['trace']['eth']['dl_vlan'] = 10
+        payload[0]['trace']['eth']['dl_type'] = "1"
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 400, response.text
+ 
+        # Valid request:
+        payload[0]['trace']['eth']['dl_type'] = 1
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 200

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -827,3 +827,60 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
         assert list_results[0][0]["port"] == 1
         assert list_results[0][-1]["type"] == "last"
+
+    def test_080_validate_attribute_on_payload(self):
+        "Validate parameters"
+
+        # Mandatory parameter missing:
+        payload = [
+                    {
+                        "trace": {
+                            "switch": {
+                                "dpid": "00:00:00:00:00:00:00:01"
+                            },
+                            "eth": {
+                                "dl_vlan": 10
+                            }
+                        }
+                    }               ]
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+        # Wrong data type:
+        payload = [
+                    {
+                        "trace": {
+                            "switch": {
+                                "dpid": 1,
+                                "in_port": 3
+                            },
+                            "eth": {
+                                "dl_vlan": 10
+                            }
+                        }
+                    }               ]
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 400, response.text
+
+        # Wrong dl_vlan:
+        payload = [
+                    {
+                        "trace": {
+                            "switch": {
+                                "dpid": "00:00:00:00:00:00:00:01",
+                                "in_port": 3
+                            },
+                            "eth": {
+                                "dl_vlan": "10"
+                            }
+                        }
+                    }               ]
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/traces'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 400, response.text
+ 


### PR DESCRIPTION
Related to [PR of sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/pull/85)

### Summary

Add test_080_validate_attribute_on_payload to test that `/traces` validates payload.

### Local Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_080_validate_attribute_on_payload
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 1 item

tests/test_e2e_40_sdntrace.py .                                          [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 98 warnings in 123.34s (0:02:03) ==================

### End-to-End Tests

N/A