### PR TITLE
Fix issue on duplicated evc

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -776,12 +776,12 @@ class TestE2ESDNTrace:
     def test_070_run_sdntrace_untagged_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is untagged in evc"""
 
-        cls.create_evc("untagged")
+        cls.create_evc("untagged", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
         payload = [
                     {
                         "trace": {
                             "switch": {
-                                "dpid": "00:00:00:00:00:00:00:01",
+                                "dpid": "00:00:00:00:00:00:00:02",
                                 "in_port": 1
                             }
                         }
@@ -793,22 +793,20 @@ class TestE2ESDNTrace:
         assert response.status_code == 200, response.text
         data = response.json()
         list_results = data["result"]
-
-        assert len(list_results[0]) == 10
-        assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
+        assert len(list_results[0]) == 2
+        assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert list_results[0][0]["port"] == 1
-        assert list_results[0][-1]["type"] == "last"
 
     def test_075_run_sdntrace_any_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is any in evc"""
-        cls.create_evc("any")
+        cls.create_evc("any", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
         time.sleep(10)
 
         payload = [
                     {
                         "trace": {
                             "switch": {
-                                "dpid": "00:00:00:00:00:00:00:01",
+                                "dpid": "00:00:00:00:00:00:00:02",
                                 "in_port": 1
                             },
                             "eth": {
@@ -824,9 +822,8 @@ class TestE2ESDNTrace:
         data = response.json()
         list_results = data["result"]
 
-        assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:01"
+        assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert list_results[0][0]["port"] == 1
-        assert list_results[0][-1]["type"] == "last"
 
     def test_080_validate_attribute_on_payload(self):
         "Validate parameters"

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -793,9 +793,11 @@ class TestE2ESDNTrace:
         assert response.status_code == 200, response.text
         data = response.json()
         list_results = data["result"]
+
         assert len(list_results[0]) == 2
         assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert list_results[0][0]["port"] == 1
+        assert list_results[0][-1]["type"] == "last"
 
     def test_075_run_sdntrace_any_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is any in evc"""
@@ -824,6 +826,7 @@ class TestE2ESDNTrace:
 
         assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert list_results[0][0]["port"] == 1
+        assert list_results[0][-1]["type"] == "last"
 
     def test_080_validate_attribute_on_payload(self):
         "Validate parameters"


### PR DESCRIPTION
Closes #221 

### Summary

`tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_070_run_sdntrace_untagged_vlan` failed when trying to create an existing evc. Note that a different evc is now created.

### Local Tests

+ python3 -m pytest tests/test_e2e_40_sdntrace.py
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 11 items

tests/test_e2e_40_sdntrace.py ...........                                [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================= 11 passed, 98 warnings in 269.62s (0:04:29) ==================


### End-to-End Tests

N/A