### PR TITLE
Fix: e2e `test_070_run_sdntrace_untagged_vlan`

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -776,22 +776,21 @@ class TestE2ESDNTrace:
     def test_070_run_sdntrace_untagged_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is untagged in evc"""
 
-        payload = {
-            "name": "Vlan_untagged",
-            "enabled": True,
-            "dynamic_backup_path": True,
-            "uni_a": {
-                "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": "untagged"}
-            },
-            "uni_z": {
-                "interface_id": "00:00:00:00:00:00:00:03:1",
-                "tag": {"tag_type": 1, "value": "untagged"}
-            }
-        }
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
-        response = requests.post(api_url, json=payload)
-        assert response.status_code in [201, 409], response.text
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'  
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        
+        uni_a = {'interface_id': '00:00:00:00:00:00:00:02:1', 'tag': {'tag_type': 1, 'value': "untagged"}}
+        uni_z = {'interface_id': '00:00:00:00:00:00:00:03:1', 'tag': {'tag_type': 1, 'value': "untagged"}}
+        for circuit_id, circuit in data.items():
+            if uni_a in (circuit['uni_a'], circuit['uni_z']) or uni_z in (circuit['uni_a'], circuit['uni_z']):
+                api_url = KYTOS_API + f'/kytos/mef_eline/v2/evc/{circuit_id}' 
+                response = requests.delete(api_url)
+                assert response.status_code == 200, response.text
+
+        cls.create_evc("untagged", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")        
+        time.sleep(10)
 
         payload = [
                     {
@@ -817,23 +816,8 @@ class TestE2ESDNTrace:
 
     def test_075_run_sdntrace_any_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is any in evc"""
-       
-        payload = {
-            "name": "Vlan_any",
-            "enabled": True,
-            "dynamic_backup_path": True,
-            "uni_a": {
-                "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": "any"}
-            },
-            "uni_z": {
-                "interface_id": "00:00:00:00:00:00:00:03:1",
-                "tag": {"tag_type": 1, "value": "any"}
-            }
-        }
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
-        response = requests.post(api_url, json=payload)
-        assert response.status_code in [201, 409], response.text
+
+        cls.create_evc("any", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
         time.sleep(10)
 
         payload = [

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -776,7 +776,23 @@ class TestE2ESDNTrace:
     def test_070_run_sdntrace_untagged_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is untagged in evc"""
 
-        cls.create_evc("untagged", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
+        payload = {
+            "name": "Vlan_untagged",
+            "enabled": True,
+            "dynamic_backup_path": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {"tag_type": 1, "value": "untagged"}
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {"tag_type": 1, "value": "untagged"}
+            }
+        }
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        response = requests.post(api_url, json=payload)
+        assert response.status_code in [201, 409], response.text
+
         payload = [
                     {
                         "trace": {
@@ -801,7 +817,23 @@ class TestE2ESDNTrace:
 
     def test_075_run_sdntrace_any_vlan(cls):
         """Run SDNTrace to test /traces endpoint when vlan is any in evc"""
-        cls.create_evc("any", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
+       
+        payload = {
+            "name": "Vlan_any",
+            "enabled": True,
+            "dynamic_backup_path": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {"tag_type": 1, "value": "any"}
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {"tag_type": 1, "value": "any"}
+            }
+        }
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        response = requests.post(api_url, json=payload)
+        assert response.status_code in [201, 409], response.text
         time.sleep(10)
 
         payload = [


### PR DESCRIPTION
Closes #225 

### Summary

e2e `test_070_run_sdntrace_untagged_vlan` fails when the evc it tries to create exists. To prevent this test from failing, it checks not only that the evc was created, but also whether it already exists. So, in these two cases `/traces` is called.

### Local Tests

tests/test_e2e_40_sdntrace.py ...........                                [100%]

=============================== warnings summary ===============================
test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_40_sdntrace.py: 49 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================= 11 passed, 98 warnings in 256.92s (0:04:16) ==================

### End-to-End Tests

N/A