### PR TITLE
Removed xfail for 040 and 090 tests

### DIFF
--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -203,7 +203,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.xfail
     def test_040_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
@@ -385,7 +384,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.xfail
     def test_090_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 


### PR DESCRIPTION
Closes #231 

### Summary

`xfail` marks are no longer needed since these tests are passing.

### Local Tests
```
+ python3 -m pytest tests/test_e2e_13_mef_eline.py -k '090 or 040' --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2
collected 44 items / 42 deselected / 2 selected

tests/test_e2e_13_mef_eline.py ..                                        [100%]

```