### PR TITLE
chore: fix routes trailing slashes inconsistencies to avoid validation errors

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -739,7 +739,7 @@ class TestE2EMefEline:
                 response = requests.delete(api_url)
                 assert response.status_code == 200, response.text
 
-            time.sleep(10)
+            time.sleep(20)
 
             # make sure the circuits were deleted
             api_url = KYTOS_API + '/mef_eline/v2/evc/'

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -707,7 +707,7 @@ class TestE2EMefEline:
                 assert 'circuit_id' in data
                 evcs[i] = data['circuit_id']
 
-            time.sleep(20)
+            time.sleep(10)
 
             # make sure the evcs are active and the flows were created
             s1, s2 = self.net.net.get('s1', 's2')
@@ -739,7 +739,7 @@ class TestE2EMefEline:
                 response = requests.delete(api_url)
                 assert response.status_code == 200, response.text
 
-            time.sleep(20)
+            time.sleep(10)
 
             # make sure the circuits were deleted
             api_url = KYTOS_API + '/mef_eline/v2/evc/'

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -707,7 +707,7 @@ class TestE2EMefEline:
                 assert 'circuit_id' in data
                 evcs[i] = data['circuit_id']
 
-            time.sleep(10)
+            time.sleep(20)
 
             # make sure the evcs are active and the flows were created
             s1, s2 = self.net.net.get('s1', 's2')

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -321,7 +321,6 @@ class TestE2EMefEline:
         data = response.json()
         expected_desc = "Additional properties are not allowed ('active' was unexpected)"
         assert data["code"] == 400
-        assert data["name"] == "Bad Request"
         assert expected_desc in data["description"]
 
     def test_026_validate_bad_request_response_format(self):
@@ -342,7 +341,6 @@ class TestE2EMefEline:
 
         data = response.json()
         assert data["code"] == 400
-        assert data["name"] == "Bad Request"
         assert "The request body contains invalid API data" in data["description"]
         assert "not of type" in data["description"]
         assert "for field uni_a/interface_id" in data["description"]

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -206,11 +206,6 @@ class TestE2EMefEline:
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
 
-        # Verify if the circuit schedule does not exist
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
-        response = requests.get(api_url)
-        assert response.status_code == 405, response.text
-
         # Verify the list of schedules
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.get(api_url)

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -107,7 +107,7 @@ class TestE2EMefEline:
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -150,7 +150,7 @@ class TestE2EMefEline:
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -182,7 +182,7 @@ class TestE2EMefEline:
         }
 
         # Create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -232,7 +232,7 @@ class TestE2EMefEline:
         }
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         json = response.json()
         assert response.status_code == 201, response.text

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -333,7 +333,7 @@ class TestE2ESDNTrace:
 
         # 4. redeploy evc and check again
         circuit_id = self.circuit['id']
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc'
         response = requests.patch(f"{api_url}/{circuit_id}/redeploy")
         assert response.status_code == 202, response.text
         time.sleep(10)

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -18,7 +18,7 @@ class TestE2ESDNTrace:
         cls.net.wait_switches_connect()
         time.sleep(10)
         circuit_id = cls.create_evc(400)
-        time.sleep(10)
+        time.sleep(20)
         cls.circuit = cls.get_evc(circuit_id)
 
     @classmethod

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -1,7 +1,6 @@
 import requests
 from tests.helpers import NetworkTest
 import time
-import pytest
 
 CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api' % CONTROLLER

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -54,16 +54,17 @@ class TestE2ESDNTrace:
         data = response.json()
         return data
 
+    @classmethod
     def wait_until_evc_is_active(
-        self, evc_id: str, wait_secs=6, i=0, max_i=20
+        cls, evc_id: str, wait_secs=6, i=0, max_i=20
     ) -> dict:
         """Wait until evc is active."""
-        evc = self.get_evc(evc_id)
+        evc = cls.get_evc(evc_id)
         if evc["active"]:
             return evc
         time.sleep(wait_secs)
         if i < max_i:
-            return self.wait_until_evc_is_active(evc_id, wait_secs, i + 1, max_i)
+            return cls.wait_until_evc_is_active(evc_id, wait_secs, i + 1, max_i)
         else:
             raise ValueError(f"TimeoutError: {evc_id} didn't get active. {evc}")
 

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -297,7 +297,7 @@ class TestE2EMaintenance:
     def test_030_create_mw_on_switch_should_fail_payload_empty(self):
         """Tests to create maintenance with the wrong payload
         Test:
-            415 response calling
+            400 response calling
             /api/kytos/maintenance/v1 on POST
         """
         self.net.restart_kytos_clean()
@@ -309,7 +309,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance/v1'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 415, response.text
+        assert response.status_code == 400, response.text
 
     def test_035_create_mw_on_switch_and_patch_new_end(self):
         """Tests the maintenance window data update

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -544,7 +544,7 @@ class TestE2EMaintenance:
 
     def test_055_patch_mw_on_switch_should_fail_empty_payload(self):
         """
-        415 response calling
+        400 response calling
             /api/kytos/maintenance/v1/{mw_id} on PATCH
         """
         self.net.restart_kytos_clean()
@@ -581,7 +581,7 @@ class TestE2EMaintenance:
         # Updates the maintenance window information
         mw_api_url = KYTOS_API + '/maintenance/v1/' + mw_id
         request = requests.patch(mw_api_url, data=json.dumps(payload1), headers={'Content-type': 'application/json'})
-        assert request.status_code == 415
+        assert request.status_code == 400
 
         # Deletes the maintenance by its id
         api_url = KYTOS_API + '/maintenance/v1/' + mw_id


### PR DESCRIPTION
Closes #236 

- I've also adapted some 4XX status code accordingly.

## Local Tests

- Reran all test suites 4 times with this branch and all `starlette` PRs related that are in code review:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py .....................                  [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
=============================== warnings summary ===============================
= 205 passed, 6 skipped, 11 xfailed, 5 xpassed, 799 warnings in 10406.12s (2:53:26) =
```

Out of 4 executions, only a single rerun happened it was the same as this old one that had been reported on issue #234