### PR TITLE
test: augmented sdntrace_cp test case to also run sdntrace for untagged/any EVC

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -787,7 +787,7 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["out"]["port"] == 1
 
     def test_070_run_sdntrace_untagged_vlan(cls):
-        """Run SDNTrace to test /traces endpoint when vlan is untagged in evc"""
+        """Run sdntrace_cp and sdntrace when vlan is untagged in evc"""
 
         api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'  
         response = requests.get(api_url)
@@ -827,8 +827,22 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["port"] == 1
         assert list_results[0][-1]["type"] == "last"
 
+        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        response = requests.put(api_url, json=payload[0])
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "result" in data, data
+        assert "trace_id" in data["result"], data
+        result = cls.wait_sdntrace_result(data["result"]["trace_id"])
+
+        assert len(result) == 3, result
+        assert result[0]["dpid"] == "00:00:00:00:00:00:00:02"
+        assert result[0]["port"] == 1
+        assert result[0]["type"] == "starting"
+        assert result[1]["dpid"] == "00:00:00:00:00:00:00:03"
+
     def test_075_run_sdntrace_any_vlan(cls):
-        """Run SDNTrace to test /traces endpoint when vlan is any in evc"""
+        """Run sdntrace_cp and sdntrace when vlan is any in evc"""
 
         cls.create_evc("any", interface_a="00:00:00:00:00:00:00:02:1", interface_z="00:00:00:00:00:00:00:03:1")
         time.sleep(10)
@@ -856,6 +870,20 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["dpid"] == "00:00:00:00:00:00:00:02"
         assert list_results[0][0]["port"] == 1
         assert list_results[0][-1]["type"] == "last"
+
+        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        response = requests.put(api_url, json=payload[0])
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "result" in data, data
+        assert "trace_id" in data["result"], data
+        result = cls.wait_sdntrace_result(data["result"]["trace_id"])
+
+        assert len(result) == 3, result
+        assert result[0]["dpid"] == "00:00:00:00:00:00:00:02"
+        assert result[0]["port"] == 1
+        assert result[0]["type"] == "starting"
+        assert result[1]["dpid"] == "00:00:00:00:00:00:00:03"
 
     def test_080_validate_attribute_on_payload(self):
         "Validate parameters"


### PR DESCRIPTION
Closes https://github.com/kytos-ng/sdntrace/issues/43

This needs `sdntrace`'s PR https://github.com/kytos-ng/sdntrace/pull/52

### Summary

- Augmented sdntrace_cp test case to also run sdntrace for untagged/any EVC
- Ideally, these should've been done in a different test case, but we have technical debt how EVCs are being created, which needs to be handled first on https://github.com/kytos-ng/kytos-end-to-end-tests/issues/239, once that's fixed then theses ones here should be moved too.

### Local Tests

I've dispatched e2e on GitLab:

```
+ python3 -m pytest tests -k 40_sdntrace --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items / 216 deselected / 11 selected
tests/test_e2e_40_sdntrace.py ...........                                [100%]
------------------------------- start/stop times -------------------------------
========= 11 passed, 216 deselected, 99 warnings in 254.86s (0:04:14) ==========
```

### End-to-End Tests

I've dispatched e2e on GitLab:

```
+ python3 -m pytest tests -k 40_sdntrace --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items / 216 deselected / 11 selected
tests/test_e2e_40_sdntrace.py ...........                                [100%]
------------------------------- start/stop times -------------------------------
========= 11 passed, 216 deselected, 99 warnings in 254.86s (0:04:14) ==========
```
