### PR TITLE
Fix bad switch ids in maintenance tests

### DIFF
--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -780,8 +780,8 @@ class TestE2EMaintenance:
             "start": start.strftime(TIME_FMT),
             "end": end.strftime(TIME_FMT),
             "switches": [
-                "00:00:00:00:00:00:02"
-            ]
+                "00:00:00:00:00:00:00:02",
+            ],
         }
 
         # Creates a new maintenance window
@@ -819,8 +819,8 @@ class TestE2EMaintenance:
             "start": start.strftime(TIME_FMT),
             "end": end.strftime(TIME_FMT),
             "switches": [
-                "00:00:00:00:00:00:02"
-            ]
+                "00:00:00:00:00:00:00:02",
+            ],
         }
 
         # Creates a new maintenance window
@@ -984,8 +984,8 @@ class TestE2EMaintenance:
             "start": start.strftime(TIME_FMT),
             "end": end.strftime(TIME_FMT),
             "switches": [
-                "00:00:00:00:00:00:02"
-            ]
+                "00:00:00:00:00:00:00:02",
+            ],
         }
 
         # Creates a new maintenance window


### PR DESCRIPTION
This fixes a minor bug in the maintenance end-to-end tests, where a few tests were attempting to create maintenance windows with incorrect switch ids. The issue associated was discovered when testing kytos-ng/maintenance#78, which adds in a validation step to check if all items in a maintenance window exist.

# End-To-End Tests

Here are the results for the end-to-end tests with kytos-ng/maintenance#78.

```
kytos-end-to-end-tests-kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-end-to-end-tests-kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-end-to-end-tests-kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-end-to-end-tests-kytos-1  | Starting ovsdb-server.
kytos-end-to-end-tests-kytos-1  | Configuring Open vSwitch system IDs.
kytos-end-to-end-tests-kytos-1  | Starting ovs-vswitchd.
kytos-end-to-end-tests-kytos-1  | Enabling remote OVSDB managers.
kytos-end-to-end-tests-kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-end-to-end-tests-kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-end-to-end-tests-kytos-1  | + kytosd --help
kytos-end-to-end-tests-kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + TESTS=tests/
kytos-end-to-end-tests-kytos-1  | + test -z ''
kytos-end-to-end-tests-kytos-1  | + RERUNS=2
kytos-end-to-end-tests-kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-end-to-end-tests-kytos-1  | Trying to run hello command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-end-to-end-tests-kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-end-to-end-tests-kytos-1  | + python3 -m pytest tests/test_e2e_50_maintenance.py
kytos-end-to-end-tests-kytos-1  | ============================= test session starts ==============================
kytos-end-to-end-tests-kytos-1  | platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
kytos-end-to-end-tests-kytos-1  | rootdir: /tests
kytos-end-to-end-tests-kytos-1  | plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
kytos-end-to-end-tests-kytos-1  | collected 24 items
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | tests/test_e2e_50_maintenance.py ........................                [100%]
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | =============================== warnings summary ===============================
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | test_e2e_50_maintenance.py: 17 warnings
kytos-end-to-end-tests-kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-end-to-end-tests-kytos-1  |     StrictVersion( '1.10' ) )
kytos-end-to-end-tests-kytos-1  | 
kytos-end-to-end-tests-kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-end-to-end-tests-kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-end-to-end-tests-kytos-1  | ================= 24 passed, 34 warnings in 1574.08s (0:26:14) =================
```