### PR TITLE
fix: adapted expected spf_attribute value

### DIFF
--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -162,7 +162,10 @@ class TestE2EMefEline:
             uni_z="00:00:00:00:00:00:00:03:1",
             vlan_id=100,
             primary_constraints={"mandatory_metrics": {"ownership": "red"}},
-            secondary_constraints={"mandatory_metrics": {"ownership": "blue"}},
+            secondary_constraints={
+                "spf_attribute": "hop",
+                "mandatory_metrics": {"ownership": "blue"}
+            },
         )
 
         time.sleep(10)
@@ -173,8 +176,7 @@ class TestE2EMefEline:
         assert data["current_path"], data["current_path"]
         assert data["failover_path"], data["failover_path"]
         assert data["primary_constraints"] == {
-            "mandatory_metrics": {"ownership": "red"},
-            "spf_attribute": "hop",
+            "mandatory_metrics": {"ownership": "red"}
         }
         assert data["secondary_constraints"] == {
             "mandatory_metrics": {"ownership": "blue"},
@@ -192,8 +194,7 @@ class TestE2EMefEline:
         self.update_evc(
             evc_id,
             primary_constraints={
-                "mandatory_metrics": {"ownership": "blue"},
-                "spf_attribute": "hop",
+                "mandatory_metrics": {"ownership": "blue"}
             },
             secondary_constraints={
                 "mandatory_metrics": {"ownership": "red"},
@@ -208,8 +209,7 @@ class TestE2EMefEline:
         assert data["current_path"], data["current_path"]
         assert data["failover_path"], data["failover_path"]
         assert data["primary_constraints"] == {
-            "mandatory_metrics": {"ownership": "blue"},
-            "spf_attribute": "hop",
+            "mandatory_metrics": {"ownership": "blue"}
         }
         assert data["secondary_constraints"] == {
             "mandatory_metrics": {"ownership": "red"},


### PR DESCRIPTION
Related to https://github.com/kytos-ng/mef_eline/pull/355 (if fixes the e2e failing test there)

### Summary

Now `spf_attribute` is only stored if it's been set, so I had to adapt this test case accordingly. 

### Local and e2e tests

```
+ python3 -m pytest tests -k test_001_create_update_with_constraints --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.2.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 239 items / 238 deselected / 1 selected
tests/test_e2e_15_mef_eline.py .                                         [100%]
=============================== warnings summary ===============================
========== 1 passed, 238 deselected, 35 warnings in 87.56s (0:01:27) ===========
```