### PR TITLE
Enhance `kytos_stats`

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -132,6 +132,16 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
+        # wait the flow to be installed
+        time.sleep(5)
+
+        # send N packets, each one containing 1500 bytes
+        # (14 ether hdr + 40 ipv6 + 8 icmp + 1438 payload)
+        h11 = self.net.net.get('h11')
+        n = 20
+        h11.cmd(f"ping -6 -b -c {n} -s 1438 FF02::2%h11-eth0 -Mdo -i 0.01 -W 2")
+
+        # give enough time for stats gathering (of_core.STATS_INTERVAL)
         time.sleep(10)
 
         api_url = KYTOS_STATS + f'/flow/stats?dpid={sw}'  

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -187,6 +187,7 @@ class TestE2EKytosStats:
         for flow_id, flow in data_flow.items():
             if flow['cookie'] == cookie:
                 bytes_counter = flow['byte_count']
+                assert bytes_counter >= n*1500, str(flow)
                 bits_per_second = 8*bytes_counter/flow['duration_sec']
                 break
         

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -151,6 +151,7 @@ class TestE2EKytosStats:
         for flow_id, flow in data_flow.items():
             if flow['cookie'] == cookie:
                 packet_counter = flow['packet_count']
+                assert packet_counter >= n, str(flow)
                 packet_per_second = packet_counter/flow['duration_sec']
                 break
         

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -34,14 +34,14 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, str(data)
+        assert len(data) == 1
         assert '00:00:00:00:00:00:00:01' in data, str(data)
 
         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01&dpid=00:00:00:00:00:00:00:02'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 2, str(data)
+        assert len(data) == 2
         assert '00:00:00:00:00:00:00:01' in data, str(data)
         assert '00:00:00:00:00:00:00:02' in data, str(data)
 
@@ -53,7 +53,7 @@ class TestE2EKytosStats:
         api_url = KYTOS_API + '/kytos/topology/v3/switches'
         response = requests.get(api_url)
         data_topp = response.json()
-        assert len(data) == len(data_topp['switches']), str(data)
+        assert len(data) == len(data_topp['switches'])
 
     def test_010_table_stats(self):
         """Test table_stats""" 
@@ -62,14 +62,14 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, str(data)
+        assert len(data) == 1
         assert '00:00:00:00:00:00:00:01' in data, str(data)
 
         api_url = KYTOS_STATS + '/table/stats?dpid=00:00:00:00:00:00:00:01&dpid=00:00:00:00:00:00:00:02' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 2, str(data)
+        assert len(data) == 2
         assert '00:00:00:00:00:00:00:01' in data, str(data)
         assert '00:00:00:00:00:00:00:02' in data, str(data)
 
@@ -82,18 +82,18 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == len(topo_switches), str(data)
+        assert len(data) == len(topo_switches)
         for sw in topo_switches:
-            assert len(data[sw]) == 1, str(data)
+            assert len(data[sw]) == 1
             assert '0' in data[sw], str(data)
 
         api_url = KYTOS_STATS + '/table/stats?table=0&table=1'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == len(topo_switches), str(data)
+        assert len(data) == len(topo_switches)
         for sw in topo_switches:
-            assert len(data[sw]) == 2, str(data)
+            assert len(data[sw]) == 2
             assert '0' in data[sw], str(data)
             assert '1' in data[sw], str(data)
 
@@ -101,15 +101,15 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == 1, str(data)
-        assert len(data['00:00:00:00:00:00:00:01']) == 1, str(data)
+        assert len(data) == 1
+        assert len(data['00:00:00:00:00:00:00:01']) == 1
         assert '0' in data['00:00:00:00:00:00:00:01'], str(data)
 
         api_url = KYTOS_STATS + '/table/stats'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data) == len(topo_switches), str(data)
+        assert len(data) == len(topo_switches)
 
     def test_015_packet_count(self):
         """Test packet_count""" 
@@ -117,14 +117,14 @@ class TestE2EKytosStats:
 
         # install a flow
         cookie = 5
-        payload = {"flows": [{"cookie": cookie, "packet_count": 8, "duration_sec": 2}]}
+        payload = {"flows": [{"cookie": cookie}]}
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
         response = requests.post(api_url_flow_manager, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
         data_flow = response.json()
-        assert 'FlowMod Messages Sent' in data_flow['response'], str(data_flow)
+        assert 'FlowMod Messages Sent' in data_flow['response']
 
         time.sleep(10)
 
@@ -142,9 +142,9 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert data['flow_id'] == flow_id, str(data)
-        assert data['packet_counter'] == packet_counter, str(data)
-        assert data['packet_per_second'] == packet_per_second, str(data)
+        assert data['flow_id'] == flow_id
+        assert data['packet_counter'] == packet_counter
+        assert data['packet_per_second'] == packet_per_second
 
     def test_020_bytes_count(self):
         """Test bytes_count""" 
@@ -152,14 +152,14 @@ class TestE2EKytosStats:
 
         # install a flow
         cookie = 5
-        payload = {"flows": [{"cookie": cookie, "byte_count": 8, "duration_sec": 2}]}
+        payload = {"flows": [{"cookie": cookie}]}
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
         response = requests.post(api_url_flow_manager, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
         data_flow = response.json()
-        assert 'FlowMod Messages Sent' in data_flow['response'], str(data_flow)
+        assert 'FlowMod Messages Sent' in data_flow['response']
 
         time.sleep(10)
 
@@ -177,9 +177,9 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert data['flow_id'] == flow_id, str(data)
-        assert data['bytes_counter'] == bytes_counter, str(data)
-        assert data['bits_per_second'] == bits_per_second, str(data)
+        assert data['flow_id'] == flow_id
+        assert data['bytes_counter'] == bytes_counter
+        assert data['bits_per_second'] == bits_per_second
 
     def test_025_packet_count_per_flow(self):
         """Test packet_count_per_flow""" 
@@ -196,8 +196,8 @@ class TestE2EKytosStats:
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['packet_count']
-            assert info_flow['packet_counter'] == count, str(info_flow)
-            assert info_flow['packet_per_second'] == count/data_flow[flow_id]['duration_sec'], str(info_flow)
+            assert info_flow['packet_counter'] == count
+            assert info_flow['packet_per_second'] == count/data_flow[flow_id]['duration_sec']
 
 
     def test_030_bytes_count_per_flow(self):
@@ -215,8 +215,8 @@ class TestE2EKytosStats:
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['byte_count']
-            assert info_flow['bytes_counter'] == count, str(info_flow)
-            assert info_flow['bits_per_second'] == 8 * count/data_flow[flow_id]['duration_sec'], str(info_flow)
+            assert info_flow['bytes_counter'] == count
+            assert info_flow['bits_per_second'] == 8 * count/data_flow[flow_id]['duration_sec']
 
     def test_035_table_fields_update(self):
         """Test fields are updating on table 0.
@@ -237,7 +237,7 @@ class TestE2EKytosStats:
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
         data_flow = response.json()
-        assert 'FlowMod Messages Sent' in data_flow['response'], str(data_flow)
+        assert 'FlowMod Messages Sent' in data_flow['response']
 
         time.sleep(10)
 
@@ -276,7 +276,7 @@ class TestE2EKytosStats:
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
         data_flow = response.json()
-        assert 'FlowMod Messages Sent' in data_flow['response'], str(data_flow)
+        assert 'FlowMod Messages Sent' in data_flow['response']
 
         time.sleep(10)
 

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -169,7 +169,13 @@ class TestE2EKytosStats:
 
         # install a flow
         cookie = 5
-        payload = {"flows": [{"cookie": cookie}]}
+        payload = {
+            "flows": [{
+                "cookie": cookie,
+                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
+                'actions': [{'action_type': 'output', 'port': 2}]
+            }]
+        }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
         response = requests.post(api_url_flow_manager, data=json.dumps(payload),

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -178,6 +178,16 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
+        # wait the flow to be installed
+        time.sleep(5)
+
+        # send N packets, each one containing 1500 bytes
+        # (14 ether hdr + 40 ipv6 + 8 icmp + 1438 payload)
+        h11 = self.net.net.get('h11')
+        n = 20
+        h11.cmd(f"ping -6 -b -c {n} -s 1438 FF02::2%h11-eth0 -Mdo -i 0.01 -W 2")
+
+        # waiting to give enough time for stats gathering (of_core.STATS_INTERVAL)
         time.sleep(10)
 
         api_url = KYTOS_STATS + f'/flow/stats?dpid={sw}'  

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -117,7 +117,13 @@ class TestE2EKytosStats:
 
         # install a flow
         cookie = 5
-        payload = {"flows": [{"cookie": cookie}]}
+        payload = {
+            "flows": [{
+                "cookie": cookie,
+                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
+                'actions': [{'action_type': 'output', 'port': 2}]
+            }]
+        }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
         response = requests.post(api_url_flow_manager, data=json.dumps(payload),


### PR DESCRIPTION
Closes #243 

### Summary

Add `test_036_table_1_active_count_update` test to create some traffic on table 1, and  make sure that the stats are accurate.

Update `test_015_packet_count` and `test_020_bytes_count` tests to avoid trying to find a non-empty flow, instead a flow is installed and query it later for stats.
