### PR TITLE
fix: changed tag_type to string

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -74,7 +74,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -84,7 +84,7 @@ class TestE2EMefEline:
 
     def test_010_list_evcs_should_be_empty(self):
         """Test if list circuits return 'no circuit stored.'."""
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         assert response.json() == {}
@@ -110,7 +110,7 @@ class TestE2EMefEline:
                 }
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -167,7 +167,7 @@ class TestE2EMefEline:
                 }
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -224,7 +224,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 103}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -279,7 +279,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -336,7 +336,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 110}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -358,7 +358,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 110}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -422,7 +422,7 @@ class TestE2EMefEline:
 
     def test_040_disable_circuit_should_remove_openflow_rules(self):
         # let's suppose that xyz is the circuit id previously created
-        # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v3/evc/xyz
+        # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v2/evc/xyz
         payload = {
             "name": "Vlan125_Test_evc1",
             "enabled": True,
@@ -436,7 +436,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -496,7 +496,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -524,7 +524,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -588,7 +588,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -640,7 +640,7 @@ class TestE2EMefEline:
         assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
 
     def test_055_delete_evc_after_restart_kytos_and_no_switch_reconnected(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         # restart the controller and change the port on purpose to avoid switches to connect
@@ -668,7 +668,7 @@ class TestE2EMefEline:
     def test_patch_evc_by_changing_unis_from_interface_to_another(self):
         """To edit an EVC, a PATCH request must be used:
 
-        PATCH /kytos/mef_eline/v3.0/evc/<id>
+        PATCH /kytos/mef_eline/v2.0/evc/<id>
 
         Information necessary to modify the EVC:
 
@@ -700,7 +700,7 @@ class TestE2EMefEline:
                         "tag": {"tag_type": "vlan", "value": i}
                     }
                 }
-                api_url = KYTOS_API + '/mef_eline/v3/evc/'
+                api_url = KYTOS_API + '/mef_eline/v2/evc/'
                 response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
                 assert response.status_code == 201, response.text
                 data = response.json()
@@ -715,7 +715,7 @@ class TestE2EMefEline:
             flows_s2 = s2.dpctl('dump-flows')
             for vid in evcs:
                 evc_id = evcs[vid]
-                api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
+                api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
                 response = requests.get(api_url)
                 assert response.status_code == 200, response.text
                 evc = response.json()
@@ -735,14 +735,14 @@ class TestE2EMefEline:
             # Delete the circuits
             for vid in evcs:
                 evc_id = evcs[vid]
-                api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
+                api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
                 response = requests.delete(api_url)
                 assert response.status_code == 200, response.text
 
             time.sleep(10)
 
             # make sure the circuits were deleted
-            api_url = KYTOS_API + '/mef_eline/v3/evc/'
+            api_url = KYTOS_API + '/mef_eline/v2/evc/'
             response = requests.get(api_url)
             assert response.status_code == 200, response.text
             assert response.json() == {}
@@ -777,7 +777,7 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         for vid in self.evcs:
 
-            api_url = KYTOS_API + '/mef_eline/v3/evc/' + self.evcs[vid]
+            api_url = KYTOS_API + '/mef_eline/v2/evc/' + self.evcs[vid]
             response = requests.get(api_url)
             assert response.status_code == 200, response.text
             evc = response.json()
@@ -798,14 +798,14 @@ class TestE2EMefEline:
         # Delete the circuits
         for vid in self.evcs:
             evc_id = self.evcs[vid]
-            api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
+            api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
             response = requests.delete(api_url)
             assert response.status_code == 200, response.text
 
         time.sleep(10)
 
         # make sure the circuits were deleted
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         assert response.json() == {}
@@ -818,7 +818,7 @@ class TestE2EMefEline:
 
     def test_090_patch_evc_new_name(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's name
@@ -842,7 +842,7 @@ class TestE2EMefEline:
         assert data['name'] == 'My EVC_100'
 
     def test_095_patch_evc_new_unis(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -864,7 +864,7 @@ class TestE2EMefEline:
         assert data['uni_a']['interface_id'] == "00:00:00:00:00:00:00:01:2"
 
     def test_100_patch_evc_new_unis(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -890,7 +890,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_105_patch_end_date(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         end_delay = 1
@@ -914,14 +914,14 @@ class TestE2EMefEline:
         time.sleep(end_delay*60+5)
 
         # Verify if the circuit is active
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc1
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc1
         response = requests.get(api_url)
         data = response.json()
         assert data["active"] is False
 
     def test_110_patch_bandwidth(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         bandwidth = 40
@@ -943,7 +943,7 @@ class TestE2EMefEline:
 
     def test_115_patch_priority(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         sb_priority = 100
@@ -971,7 +971,7 @@ class TestE2EMefEline:
 
     def test_120_patch_queue_id(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         queue_id = 3
@@ -1000,7 +1000,7 @@ class TestE2EMefEline:
     def test_125_patch_dynamic_backup_path(self):
         """Test patching an EVC to be non dynamic with primary_path."""
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         dynamic_backup_path = False
@@ -1030,7 +1030,7 @@ class TestE2EMefEline:
         """Test try to patch dynamic_backup_path as False with an EVC
         that doesn't have a static primary_path."""
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
         payload = {
             "dynamic_backup_path": False,
@@ -1046,7 +1046,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_130_patch_primary_path(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1095,7 +1095,7 @@ class TestE2EMefEline:
 
     def test_135_patch_backup_path(self):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -1177,7 +1177,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1224,7 +1224,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1289,7 +1289,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1315,14 +1315,14 @@ class TestE2EMefEline:
 
     def test_155_removing_evc_metadata_persistent(self):
         """
-        Test /api/kytos/mef_eline/v3/evc/{evc_id}/metadata/{key} on DELETE
+        Test /api/kytos/mef_eline/v2/evc/{evc_id}/metadata/{key} on DELETE
         supported by:
-            /api/kytos/mef_eline/v3/evc/{evc_id}/metadata on POST
+            /api/kytos/mef_eline/v2/evc/{evc_id}/metadata on POST
             and
-            /api/kytos/mef_eline/v3/evc/{evc_id}/metadata on GET
+            /api/kytos/mef_eline/v2/evc/{evc_id}/metadata on GET
         """
         evc1 = self.create_evc(100)
-        api_url = KYTOS_API + '/mef_eline/v3/evc/%s/metadata' % evc1
+        api_url = KYTOS_API + '/mef_eline/v2/evc/%s/metadata' % evc1
 
         # Make sure the metadata is initially empty
         response = requests.get(api_url)
@@ -1394,7 +1394,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1444,7 +1444,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1499,7 +1499,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1569,7 +1569,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1640,7 +1640,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1695,7 +1695,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1745,7 +1745,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1790,7 +1790,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1849,7 +1849,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1912,7 +1912,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1956,7 +1956,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=evc_1)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1975,7 +1975,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=evc_2)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1988,11 +1988,11 @@ class TestE2EMefEline:
             "circuit_ids":[evc_1_id, evc_2_id],
             "test": "data"
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/metadata'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/metadata'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc?metadata.test=data'
+        api_url = KYTOS_API + '/mef_eline/v2/evc?metadata.test=data'
         response = requests.get(api_url, json=payload)
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -162,7 +162,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 15
                 }
             }
@@ -217,7 +217,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 102}
+                "tag": {"tag_type": 1, "value": 102}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
@@ -329,11 +329,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 110}
+                "tag": {"tag_type": 1, "value": 110}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 110}
+                "tag": {"tag_type": 1, "value": 110}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -433,7 +433,7 @@ class TestE2EMefEline:
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 125}
+                "tag": {"tag_type": 1, "value": 125}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -517,11 +517,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 125}
+                "tag": {"tag_type": 1, "value": 125}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 125}
+                "tag": {"tag_type": 1, "value": 125}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -693,7 +693,7 @@ class TestE2EMefEline:
                     "dynamic_backup_path": True,
                     "uni_a": {
                         "interface_id": "00:00:00:00:00:00:00:01:1",
-                        "tag": {"tag_type": "vlan", "value": i}
+                        "tag": {"tag_type": 1, "value": i}
                     },
                     "uni_z": {
                         "interface_id": "00:00:00:00:00:00:00:02:1",
@@ -1102,14 +1102,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 101
                 }
             },
@@ -1216,11 +1216,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             }
         }
 
@@ -1281,7 +1281,7 @@ class TestE2EMefEline:
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             "primary_path": [
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
@@ -1386,7 +1386,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": "untagged"},
+                "tag": {"tag_type": 1, "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
@@ -1440,7 +1440,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": "any"},
+                "tag": {"tag_type": 1, "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1491,7 +1491,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": "any"},
+                "tag": {"tag_type": 1, "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
@@ -1565,7 +1565,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": "untagged"},
+                "tag": {"tag_type": 1, "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1631,7 +1631,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": "any"},
+                "tag": {"tag_type": 1, "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
@@ -1691,7 +1691,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": "any"},
+                "tag": {"tag_type": 1, "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1737,7 +1737,7 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": "untagged"},
+                "tag": {"tag_type": 1, "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
@@ -1786,7 +1786,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": 100},
+                "tag": {"tag_type": 1, "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1841,7 +1841,7 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": 100},
+                "tag": {"tag_type": 1, "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
@@ -1908,7 +1908,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": "untagged"},
+                "tag": {"tag_type": 1, "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1967,11 +1967,11 @@ class TestE2EMefEline:
             "name": "EVC_2",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": "vlan", "value": 100},
+                "tag": {"tag_type": 1, "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:02:1",
             },
             "uni_z": {
-                "tag": {"tag_type": "vlan", "value": 2200},
+                "tag": {"tag_type": 1, "value": 2200},
                 "interface_id": "00:00:00:00:00:00:00:02:2",
             }
         }

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -74,7 +74,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -84,7 +84,7 @@ class TestE2EMefEline:
 
     def test_010_list_evcs_should_be_empty(self):
         """Test if list circuits return 'no circuit stored.'."""
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         assert response.json() == {}
@@ -110,7 +110,7 @@ class TestE2EMefEline:
                 }
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -167,7 +167,7 @@ class TestE2EMefEline:
                 }
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -224,7 +224,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 103}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -279,7 +279,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -336,7 +336,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 110}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -358,7 +358,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 110}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -422,7 +422,7 @@ class TestE2EMefEline:
 
     def test_040_disable_circuit_should_remove_openflow_rules(self):
         # let's suppose that xyz is the circuit id previously created
-        # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v2/evc/xyz
+        # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v3/evc/xyz
         payload = {
             "name": "Vlan125_Test_evc1",
             "enabled": True,
@@ -436,7 +436,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -496,7 +496,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -524,7 +524,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": 125}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -588,7 +588,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -640,7 +640,7 @@ class TestE2EMefEline:
         assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
 
     def test_055_delete_evc_after_restart_kytos_and_no_switch_reconnected(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         # restart the controller and change the port on purpose to avoid switches to connect
@@ -668,7 +668,7 @@ class TestE2EMefEline:
     def test_patch_evc_by_changing_unis_from_interface_to_another(self):
         """To edit an EVC, a PATCH request must be used:
 
-        PATCH /kytos/mef_eline/v2.0/evc/<id>
+        PATCH /kytos/mef_eline/v3.0/evc/<id>
 
         Information necessary to modify the EVC:
 
@@ -700,7 +700,7 @@ class TestE2EMefEline:
                         "tag": {"tag_type": "vlan", "value": i}
                     }
                 }
-                api_url = KYTOS_API + '/mef_eline/v2/evc/'
+                api_url = KYTOS_API + '/mef_eline/v3/evc/'
                 response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
                 assert response.status_code == 201, response.text
                 data = response.json()
@@ -715,7 +715,7 @@ class TestE2EMefEline:
             flows_s2 = s2.dpctl('dump-flows')
             for vid in evcs:
                 evc_id = evcs[vid]
-                api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
+                api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
                 response = requests.get(api_url)
                 assert response.status_code == 200, response.text
                 evc = response.json()
@@ -735,14 +735,14 @@ class TestE2EMefEline:
             # Delete the circuits
             for vid in evcs:
                 evc_id = evcs[vid]
-                api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
+                api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
                 response = requests.delete(api_url)
                 assert response.status_code == 200, response.text
 
             time.sleep(10)
 
             # make sure the circuits were deleted
-            api_url = KYTOS_API + '/mef_eline/v2/evc/'
+            api_url = KYTOS_API + '/mef_eline/v3/evc/'
             response = requests.get(api_url)
             assert response.status_code == 200, response.text
             assert response.json() == {}
@@ -777,7 +777,7 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         for vid in self.evcs:
 
-            api_url = KYTOS_API + '/mef_eline/v2/evc/' + self.evcs[vid]
+            api_url = KYTOS_API + '/mef_eline/v3/evc/' + self.evcs[vid]
             response = requests.get(api_url)
             assert response.status_code == 200, response.text
             evc = response.json()
@@ -798,14 +798,14 @@ class TestE2EMefEline:
         # Delete the circuits
         for vid in self.evcs:
             evc_id = self.evcs[vid]
-            api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
+            api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc_id
             response = requests.delete(api_url)
             assert response.status_code == 200, response.text
 
         time.sleep(10)
 
         # make sure the circuits were deleted
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         assert response.json() == {}
@@ -818,7 +818,7 @@ class TestE2EMefEline:
 
     def test_090_patch_evc_new_name(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's name
@@ -842,7 +842,7 @@ class TestE2EMefEline:
         assert data['name'] == 'My EVC_100'
 
     def test_095_patch_evc_new_unis(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -864,7 +864,7 @@ class TestE2EMefEline:
         assert data['uni_a']['interface_id'] == "00:00:00:00:00:00:00:01:2"
 
     def test_100_patch_evc_new_unis(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -890,7 +890,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_105_patch_end_date(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         end_delay = 1
@@ -914,14 +914,14 @@ class TestE2EMefEline:
         time.sleep(end_delay*60+5)
 
         # Verify if the circuit is active
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc1
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + evc1
         response = requests.get(api_url)
         data = response.json()
         assert data["active"] is False
 
     def test_110_patch_bandwidth(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         bandwidth = 40
@@ -943,7 +943,7 @@ class TestE2EMefEline:
 
     def test_115_patch_priority(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         sb_priority = 100
@@ -971,7 +971,7 @@ class TestE2EMefEline:
 
     def test_120_patch_queue_id(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         queue_id = 3
@@ -1000,7 +1000,7 @@ class TestE2EMefEline:
     def test_125_patch_dynamic_backup_path(self):
         """Test patching an EVC to be non dynamic with primary_path."""
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         dynamic_backup_path = False
@@ -1030,7 +1030,7 @@ class TestE2EMefEline:
         """Test try to patch dynamic_backup_path as False with an EVC
         that doesn't have a static primary_path."""
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
         payload = {
             "dynamic_backup_path": False,
@@ -1046,7 +1046,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_130_patch_primary_path(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1095,7 +1095,7 @@ class TestE2EMefEline:
 
     def test_135_patch_backup_path(self):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -1177,7 +1177,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1224,7 +1224,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1289,7 +1289,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         evc1 = data['circuit_id']
@@ -1315,14 +1315,14 @@ class TestE2EMefEline:
 
     def test_155_removing_evc_metadata_persistent(self):
         """
-        Test /api/kytos/mef_eline/v2/evc/{evc_id}/metadata/{key} on DELETE
+        Test /api/kytos/mef_eline/v3/evc/{evc_id}/metadata/{key} on DELETE
         supported by:
-            /api/kytos/mef_eline/v2/evc/{evc_id}/metadata on POST
+            /api/kytos/mef_eline/v3/evc/{evc_id}/metadata on POST
             and
-            /api/kytos/mef_eline/v2/evc/{evc_id}/metadata on GET
+            /api/kytos/mef_eline/v3/evc/{evc_id}/metadata on GET
         """
         evc1 = self.create_evc(100)
-        api_url = KYTOS_API + '/mef_eline/v2/evc/%s/metadata' % evc1
+        api_url = KYTOS_API + '/mef_eline/v3/evc/%s/metadata' % evc1
 
         # Make sure the metadata is initially empty
         response = requests.get(api_url)
@@ -1394,7 +1394,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1444,7 +1444,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1499,7 +1499,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1569,7 +1569,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1640,7 +1640,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1695,7 +1695,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1745,7 +1745,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1790,7 +1790,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1849,7 +1849,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1912,7 +1912,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1956,7 +1956,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=evc_1)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1975,7 +1975,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:02:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=evc_2)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -1988,11 +1988,11 @@ class TestE2EMefEline:
             "circuit_ids":[evc_1_id, evc_2_id],
             "test": "data"
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/metadata'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/metadata'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc?metadata.test=data'
+        api_url = KYTOS_API + '/mef_eline/v3/evc?metadata.test=data'
         response = requests.get(api_url, json=payload)
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -67,11 +67,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -98,14 +98,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:2",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             }
@@ -155,14 +155,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 15
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 15
                 }
             }
@@ -217,11 +217,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 102}
+                "tag": {"tag_type": "vlan", "value": 102}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 103}
+                "tag": {"tag_type": "vlan", "value": 103}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -273,7 +273,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 104}
+                "tag": {"tag_type": "vlan", "value": 104}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1"
@@ -329,11 +329,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 110}
+                "tag": {"tag_type": "vlan", "value": 110}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 110}
+                "tag": {"tag_type": "vlan", "value": 110}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -351,11 +351,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:2",
-                "tag": {"tag_type": 1, "value": 110}
+                "tag": {"tag_type": "vlan", "value": 110}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
-                "tag": {"tag_type": 1, "value": 110}
+                "tag": {"tag_type": "vlan", "value": 110}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -429,11 +429,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -489,11 +489,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -517,11 +517,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 125}
+                "tag": {"tag_type": "vlan", "value": 125}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -565,14 +565,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
@@ -693,11 +693,11 @@ class TestE2EMefEline:
                     "dynamic_backup_path": True,
                     "uni_a": {
                         "interface_id": "00:00:00:00:00:00:00:01:1",
-                        "tag": {"tag_type": 1, "value": i}
+                        "tag": {"tag_type": "vlan", "value": i}
                     },
                     "uni_z": {
                         "interface_id": "00:00:00:00:00:00:00:02:1",
-                        "tag": {"tag_type": 1, "value": i}
+                        "tag": {"tag_type": "vlan", "value": i}
                     }
                 }
                 api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1102,14 +1102,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
@@ -1165,11 +1165,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "primary_path": [
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
@@ -1216,11 +1216,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             }
         }
 
@@ -1277,11 +1277,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": False,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "primary_path": [
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
@@ -1386,11 +1386,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1436,11 +1436,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1491,11 +1491,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1561,11 +1561,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1631,11 +1631,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1"
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:02:1"
             }
         }
@@ -1687,11 +1687,11 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1737,11 +1737,11 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1782,11 +1782,11 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1841,11 +1841,11 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1904,11 +1904,11 @@ class TestE2EMefEline:
             "name": "my evc1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": "any"},
+                "tag": {"tag_type": "vlan", "value": "any"},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": "untagged"},
+                "tag": {"tag_type": "vlan", "value": "untagged"},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1948,11 +1948,11 @@ class TestE2EMefEline:
             "name": "EVC_1",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": 200},
+                "tag": {"tag_type": "vlan", "value": 200},
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
@@ -1967,11 +1967,11 @@ class TestE2EMefEline:
             "name": "EVC_2",
             "enabled": True,
             "uni_a": {
-                "tag": {"tag_type": 1, "value": 100},
+                "tag": {"tag_type": "vlan", "value": 100},
                 "interface_id": "00:00:00:00:00:00:00:02:1",
             },
             "uni_z": {
-                "tag": {"tag_type": 1, "value": 2200},
+                "tag": {"tag_type": "vlan", "value": 2200},
                 "interface_id": "00:00:00:00:00:00:00:02:2",
             }
         }

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -79,7 +79,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -144,7 +144,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert r.status_code == 201, r.text
 
@@ -205,7 +205,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert r.status_code == 201, r.text
 
@@ -256,7 +256,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -314,7 +314,7 @@ class TestE2EMefEline:
             "active": True,
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -335,7 +335,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:03:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -54,7 +54,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 101
                 }
             },
@@ -126,7 +126,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 101
                 }
             },
@@ -302,7 +302,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 101
                 }
             },

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -54,14 +54,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
@@ -126,14 +126,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
@@ -295,14 +295,14 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 101
                 }
             },

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -79,7 +79,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -144,7 +144,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert r.status_code == 201, r.text
 
@@ -205,7 +205,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert r.status_code == 201, r.text
 
@@ -256,7 +256,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 201, response.text
 
@@ -314,7 +314,7 @@ class TestE2EMefEline:
             "active": True,
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -335,7 +335,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:03:1"
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -49,7 +49,7 @@ class TestE2EMefEline:
         return circuit_id
 
     def _circuit_exists(self, circuit_id):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.get(api_url)
         return response.status_code == 200
 
@@ -64,7 +64,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -81,7 +81,7 @@ class TestE2EMefEline:
         payload = {
             "enable": False,
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.patch(api_url, json=payload)
 
         assert response.status_code == 200, response.text
@@ -101,13 +101,13 @@ class TestE2EMefEline:
         }
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -116,7 +116,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -144,13 +144,13 @@ class TestE2EMefEline:
         }
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -159,7 +159,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -182,12 +182,12 @@ class TestE2EMefEline:
         }
 
         # Create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
         # Verify the list of schedules
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -196,18 +196,18 @@ class TestE2EMefEline:
         assert len(response.json()) == 1
 
         # Recover schedule id created
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.get(api_url)
         json = response.json()
         schedule_id = json.get("circuit_scheduler")[0].get("id")
 
         # Delete circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/' + schedule_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
 
         # Verify the list of schedules
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -227,7 +227,7 @@ class TestE2EMefEline:
         }
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.post(api_url, json=payload)
         json = response.json()
         assert response.status_code == 201, response.text
@@ -236,7 +236,7 @@ class TestE2EMefEline:
         schedule_id = json.get("id")
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
@@ -247,7 +247,7 @@ class TestE2EMefEline:
         }
 
         # patch circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/' + schedule_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.patch(api_url, json=payload)
         assert response.status_code == 200, response.text
 
@@ -256,7 +256,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
 
@@ -270,7 +270,7 @@ class TestE2EMefEline:
         """ Test circuit listing action. """
 
         # List all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -290,7 +290,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_patch_start_date_in_no_scheduled_circuit(self, circuit_id):
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         start_delay = 60
         start = datetime.now() + timedelta(minutes=start_delay)
 
@@ -331,7 +331,7 @@ class TestE2EMefEline:
         }
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         requests.post(api_url, json=payload)
 
         # It verifies circuit schedule data
@@ -353,7 +353,7 @@ class TestE2EMefEline:
         time.sleep(10)
 
         # It verifies EVC's data
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url + disabled_circuit_id)
         data = response.json()
         assert data['start_date'] == start.strftime(TIME_FMT)
@@ -362,7 +362,7 @@ class TestE2EMefEline:
         """ Test circuit removal action. """
 
         # Delete the circuit
-        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
 
@@ -370,7 +370,7 @@ class TestE2EMefEline:
 
         # Verify circuit removal by
         # listing all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -49,7 +49,7 @@ class TestE2EMefEline:
         return circuit_id
 
     def _circuit_exists(self, circuit_id):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
         response = requests.get(api_url)
         return response.status_code == 200
 
@@ -64,7 +64,7 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:2",
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -81,7 +81,7 @@ class TestE2EMefEline:
         payload = {
             "enable": False,
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
         response = requests.patch(api_url, json=payload)
 
         assert response.status_code == 200, response.text
@@ -101,13 +101,13 @@ class TestE2EMefEline:
         }
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -116,7 +116,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -144,13 +144,13 @@ class TestE2EMefEline:
         }
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
@@ -159,7 +159,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -182,12 +182,12 @@ class TestE2EMefEline:
         }
 
         # Create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
         # Verify the list of schedules
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -196,18 +196,18 @@ class TestE2EMefEline:
         assert len(response.json()) == 1
 
         # Recover schedule id created
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
         response = requests.get(api_url)
         json = response.json()
         schedule_id = json.get("circuit_scheduler")[0].get("id")
 
         # Delete circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/' + schedule_id
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
 
         # Verify the list of schedules
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
 
@@ -227,7 +227,7 @@ class TestE2EMefEline:
         }
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         response = requests.post(api_url, json=payload)
         json = response.json()
         assert response.status_code == 201, response.text
@@ -236,7 +236,7 @@ class TestE2EMefEline:
         schedule_id = json.get("id")
 
         # verify if the circuit is really disabled
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
         assert json.get("enabled") is False
@@ -247,7 +247,7 @@ class TestE2EMefEline:
         }
 
         # patch circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/' + schedule_id
         response = requests.patch(api_url, json=payload)
         assert response.status_code == 200, response.text
 
@@ -256,7 +256,7 @@ class TestE2EMefEline:
         time.sleep(sched_wait)
 
         # Verify if the circuit is enabled
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
 
@@ -270,7 +270,7 @@ class TestE2EMefEline:
         """ Test circuit listing action. """
 
         # List all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -290,7 +290,7 @@ class TestE2EMefEline:
     @pytest.mark.xfail
     def test_patch_start_date_in_no_scheduled_circuit(self, circuit_id):
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         start_delay = 60
         start = datetime.now() + timedelta(minutes=start_delay)
 
@@ -331,7 +331,7 @@ class TestE2EMefEline:
         }
 
         # create circuit schedule
-        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/schedule/'
         requests.post(api_url, json=payload)
 
         # It verifies circuit schedule data
@@ -353,7 +353,7 @@ class TestE2EMefEline:
         time.sleep(10)
 
         # It verifies EVC's data
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url + disabled_circuit_id)
         data = response.json()
         assert data['start_date'] == start.strftime(TIME_FMT)
@@ -362,7 +362,7 @@ class TestE2EMefEline:
         """ Test circuit removal action. """
 
         # Delete the circuit
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        api_url = KYTOS_API + '/mef_eline/v3/evc/' + circuit_id
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
 
@@ -370,7 +370,7 @@ class TestE2EMefEline:
 
         # Verify circuit removal by
         # listing all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -56,7 +56,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         if store:
@@ -64,7 +64,7 @@ class TestE2EMefEline:
         return data['circuit_id']
 
     def test_005_patch_unknown_circuit(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         time.sleep(10)
@@ -92,7 +92,7 @@ class TestE2EMefEline:
         assert data == data2
 
     def test_010_patch_an_empty_uni_a(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -107,7 +107,7 @@ class TestE2EMefEline:
     def test_015_patch_an_inconsistent_uni_a(self):
         """ No existing switch """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -124,7 +124,7 @@ class TestE2EMefEline:
     def test_020_patch_an_inconsistent_uni_a(self):
         """ Valid switch but invalid Interface ID """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -139,16 +139,16 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_025_patch_an_inconsistent_uni_a(self):
-        """ Valid switch, valid Interface ID, but invalid tag_type (string) """
+        """ Valid switch, valid Interface ID, but invalid tag_type (int) """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "A",
+                    "tag_type": 1,
                     "value": 101
                 }
             }
@@ -163,7 +163,7 @@ class TestE2EMefEline:
     def test_030_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -185,7 +185,7 @@ class TestE2EMefEline:
     def test_035_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -206,7 +206,7 @@ class TestE2EMefEline:
     def test_040_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -228,7 +228,7 @@ class TestE2EMefEline:
     def test_045_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -249,7 +249,7 @@ class TestE2EMefEline:
     def test_050_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -273,7 +273,7 @@ class TestE2EMefEline:
         pass
 
     def test_060_patch_an_empty_uni_z(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -288,7 +288,7 @@ class TestE2EMefEline:
     def test_065_patch_an_inconsistent_uni_z(self):
         """ No existing switch """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -305,7 +305,7 @@ class TestE2EMefEline:
     def test_070_patch_an_inconsistent_uni_z(self):
         """ Valid switch but invalid Interface ID """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -320,16 +320,16 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_075_patch_an_inconsistent_uni_z(self):
-        """ Valid switch, valid Interface ID, but invalid tag_type (string) """
+        """ Valid switch, valid Interface ID, but invalid tag_type (int) """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "A",
+                    "tag_type": 1,
                     "value": 101
                 }
             }
@@ -344,7 +344,7 @@ class TestE2EMefEline:
     def test_080_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -366,7 +366,7 @@ class TestE2EMefEline:
     def test_085_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -387,7 +387,7 @@ class TestE2EMefEline:
     def test_090_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -409,7 +409,7 @@ class TestE2EMefEline:
     def test_095_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -430,7 +430,7 @@ class TestE2EMefEline:
     def test_100_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -451,7 +451,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_105_patch_an_inconsistent_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -499,7 +499,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_110_patch_an_unrelated_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -546,7 +546,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_115_patch_an_empty_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -587,7 +587,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_120_patch_an_inconsistent_backup_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -639,7 +639,7 @@ class TestE2EMefEline:
         assert data['active'] is True
 
     def test_125_patch_an_unrelated_backup_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -693,7 +693,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_130_patch_an_inconsistent_primary_links(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -741,7 +741,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_135_patch_an_unrelated_primary_links(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -789,7 +789,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_140_patch_an_inconsistent_backup_links(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -843,7 +843,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_145_patch_an_unrelated_backup_links(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -896,7 +896,7 @@ class TestE2EMefEline:
         assert data['active'] is True
 
     def test_150_patch_creation_time(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's data
@@ -921,7 +921,7 @@ class TestE2EMefEline:
         assert data['creation_time'] == creation_time
 
     def test_155_patch_evc_active(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -941,7 +941,7 @@ class TestE2EMefEline:
     """It is returning Response 200, should be 400"""
     @pytest.mark.xfail
     def test_160_patch_request_time(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         start = datetime.now()
@@ -960,7 +960,7 @@ class TestE2EMefEline:
         assert data['request_time'] != start.strftime(TIME_FMT)
 
     def test_165_patch_current_path(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1013,7 +1013,7 @@ class TestE2EMefEline:
         assert data["current_path"][0]["active"] is True
 
     def test_170_post_invalid_json(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload = {
             "unknown_tag": "my evc1",
         }
@@ -1023,14 +1023,14 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_175_post_empty_json(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload = {}
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
     def test_180_post_unknown_port_on_interface(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1048,7 +1048,7 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_185_post_unknown_interface(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1066,7 +1066,7 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_190_post_an_evc_twice(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1088,7 +1088,7 @@ class TestE2EMefEline:
         assert response.status_code == 409, response.text
 
     def test_195_get_unknown_circuit(self):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's data
@@ -1114,7 +1114,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1134,7 +1134,7 @@ class TestE2EMefEline:
             'primary_path': []
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1153,7 +1153,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1172,7 +1172,7 @@ class TestE2EMefEline:
             'primary_path': []
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1190,7 +1190,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -56,7 +56,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         data = response.json()
         if store:
@@ -64,7 +64,7 @@ class TestE2EMefEline:
         return data['circuit_id']
 
     def test_005_patch_unknown_circuit(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         time.sleep(10)
@@ -92,7 +92,7 @@ class TestE2EMefEline:
         assert data == data2
 
     def test_010_patch_an_empty_uni_a(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -107,7 +107,7 @@ class TestE2EMefEline:
     def test_015_patch_an_inconsistent_uni_a(self):
         """ No existing switch """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -124,7 +124,7 @@ class TestE2EMefEline:
     def test_020_patch_an_inconsistent_uni_a(self):
         """ Valid switch but invalid Interface ID """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -138,32 +138,11 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    def test_025_patch_an_inconsistent_uni_a(self):
-        """ Valid switch, valid Interface ID, but invalid tag_type (int) """
-
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
-        evc1 = self.create_evc(100)
-
-        payload = {
-            "uni_a": {
-                "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {
-                    "tag_type": 1,
-                    "value": 101
-                }
-            }
-        }
-
-        # It tries to setting up a new uni_a
-        response = requests.patch(api_url + evc1, data=json.dumps(payload),
-                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400, response.text
-
     @pytest.mark.xfail
     def test_030_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -185,7 +164,7 @@ class TestE2EMefEline:
     def test_035_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -206,7 +185,7 @@ class TestE2EMefEline:
     def test_040_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -228,7 +207,7 @@ class TestE2EMefEline:
     def test_045_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -249,7 +228,7 @@ class TestE2EMefEline:
     def test_050_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -273,7 +252,7 @@ class TestE2EMefEline:
         pass
 
     def test_060_patch_an_empty_uni_z(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -288,7 +267,7 @@ class TestE2EMefEline:
     def test_065_patch_an_inconsistent_uni_z(self):
         """ No existing switch """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -305,7 +284,7 @@ class TestE2EMefEline:
     def test_070_patch_an_inconsistent_uni_z(self):
         """ Valid switch but invalid Interface ID """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -319,32 +298,11 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    def test_075_patch_an_inconsistent_uni_z(self):
-        """ Valid switch, valid Interface ID, but invalid tag_type (int) """
-
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
-        evc1 = self.create_evc(100)
-
-        payload = {
-            "uni_z": {
-                "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {
-                    "tag_type": 1,
-                    "value": 101
-                }
-            }
-        }
-
-        # It tries to setting up a new uni_z
-        response = requests.patch(api_url + evc1, data=json.dumps(payload),
-                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400, response.text
-
     @pytest.mark.xfail
     def test_080_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -366,7 +324,7 @@ class TestE2EMefEline:
     def test_085_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -387,7 +345,7 @@ class TestE2EMefEline:
     def test_090_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -409,7 +367,7 @@ class TestE2EMefEline:
     def test_095_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -430,7 +388,7 @@ class TestE2EMefEline:
     def test_100_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -451,7 +409,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_105_patch_an_inconsistent_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -499,7 +457,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_110_patch_an_unrelated_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -546,7 +504,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_115_patch_an_empty_primary_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -587,7 +545,7 @@ class TestE2EMefEline:
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
     def test_120_patch_an_inconsistent_backup_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -639,7 +597,7 @@ class TestE2EMefEline:
         assert data['active'] is True
 
     def test_125_patch_an_unrelated_backup_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -693,7 +651,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_130_patch_an_inconsistent_primary_links(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -741,7 +699,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_135_patch_an_unrelated_primary_links(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -789,7 +747,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_140_patch_an_inconsistent_backup_links(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -843,7 +801,7 @@ class TestE2EMefEline:
     """It is returning Response [500], should be 400"""
     @pytest.mark.xfail
     def test_145_patch_an_unrelated_backup_links(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -896,7 +854,7 @@ class TestE2EMefEline:
         assert data['active'] is True
 
     def test_150_patch_creation_time(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's data
@@ -921,7 +879,7 @@ class TestE2EMefEline:
         assert data['creation_time'] == creation_time
 
     def test_155_patch_evc_active(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         payload = {
@@ -941,7 +899,7 @@ class TestE2EMefEline:
     """It is returning Response 200, should be 400"""
     @pytest.mark.xfail
     def test_160_patch_request_time(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         start = datetime.now()
@@ -960,7 +918,7 @@ class TestE2EMefEline:
         assert data['request_time'] != start.strftime(TIME_FMT)
 
     def test_165_patch_current_path(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1013,7 +971,7 @@ class TestE2EMefEline:
         assert data["current_path"][0]["active"] is True
 
     def test_170_post_invalid_json(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {
             "unknown_tag": "my evc1",
         }
@@ -1023,14 +981,14 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_175_post_empty_json(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {}
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
     def test_180_post_unknown_port_on_interface(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1048,7 +1006,7 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_185_post_unknown_interface(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1066,7 +1024,7 @@ class TestE2EMefEline:
         assert response.status_code == 400, response.text
 
     def test_190_post_an_evc_twice(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
@@ -1088,7 +1046,7 @@ class TestE2EMefEline:
         assert response.status_code == 409, response.text
 
     def test_195_get_unknown_circuit(self):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         # It verifies EVC's data
@@ -1114,7 +1072,7 @@ class TestE2EMefEline:
             ]
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1134,7 +1092,7 @@ class TestE2EMefEline:
             'primary_path': []
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1153,7 +1111,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1172,7 +1130,7 @@ class TestE2EMefEline:
             'primary_path': []
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
@@ -1190,7 +1148,7 @@ class TestE2EMefEline:
             }
         }
 
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -214,7 +214,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 99999
                 }
             }
@@ -331,7 +331,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": -1
                 }
             }
@@ -374,7 +374,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": 99999
                 }
             }
@@ -1060,7 +1060,7 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
@@ -1083,11 +1083,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": False,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             'primary_path': []
         }
@@ -1121,11 +1121,11 @@ class TestE2EMefEline:
             "enabled": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
             'primary_path': []
         }

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -49,11 +49,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -170,7 +170,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 2,
+                    "tag_type": "vlan_qinq",
                     "value": 101
                 }
             }
@@ -192,7 +192,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": -1
                 }
             }
@@ -213,7 +213,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": "bla"
                 }
             }
@@ -235,7 +235,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 99999
                 }
             }
@@ -256,7 +256,7 @@ class TestE2EMefEline:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type_one": 1,
+                    "tag_type_one": "vlan",
                     "value": 101
                 }
             }
@@ -351,7 +351,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 2,
+                    "tag_type": "vlan_qinq",
                     "value": 101
                 }
             }
@@ -373,7 +373,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": -1
                 }
             }
@@ -394,7 +394,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": "bla"
                 }
             }
@@ -416,7 +416,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": 99999
                 }
             }
@@ -437,7 +437,7 @@ class TestE2EMefEline:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type_one": 1,
+                    "tag_type_one": "vlan",
                     "value": 101
                 }
             }
@@ -997,7 +997,7 @@ class TestE2EMefEline:
                       "metadata": {}},
                  "active": False,
                  "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
-                 "metadata": {"s_vlan": {"value": 43, "tag_type": 1}}}]
+                 "metadata": {"s_vlan": {"value": 43, "tag_type": "vlan"}}}]
         }
 
         # It sets a new circuit's creation_time
@@ -1102,11 +1102,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "backup_path": [
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
@@ -1125,11 +1125,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": False,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             'primary_path': []
         }
@@ -1145,11 +1145,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": False,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             }
         }
 
@@ -1163,11 +1163,11 @@ class TestE2EMefEline:
             "enabled": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             'primary_path': []
         }
@@ -1182,11 +1182,11 @@ class TestE2EMefEline:
             "enabled": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             }
         }
 

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -59,7 +59,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         data = response.json()
         return data['circuit_id']
@@ -71,7 +71,7 @@ class TestE2EMefEline:
     def test_005_create_evc_on_nni(self):
         """Test to evaluate how mef_eline will behave when the uni is actually
         an NNI."""
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(uni_a='00:00:00:00:00:00:00:16:5',
                                uni_z='00:00:00:00:00:00:00:11:1',
                                vlan_id=100)

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -56,7 +56,7 @@ class TestE2EMefEline:
             },
             "uni_z": {
                 "interface_id": uni_z,
-                "tag": {"tag_type": "vlan", "value": vlan_id}
+                "tag": {"tag_type": 1, "value": vlan_id}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -52,11 +52,11 @@ class TestE2EMefEline:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": uni_a,
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             },
             "uni_z": {
                 "interface_id": uni_z,
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -59,7 +59,7 @@ class TestE2EMefEline:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         data = response.json()
         return data['circuit_id']
@@ -71,7 +71,7 @@ class TestE2EMefEline:
     def test_005_create_evc_on_nni(self):
         """Test to evaluate how mef_eline will behave when the uni is actually
         an NNI."""
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         evc1 = self.create_evc(uni_a='00:00:00:00:00:00:00:16:5',
                                uni_z='00:00:00:00:00:00:00:11:1',
                                vlan_id=100)

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -84,7 +84,7 @@ class TestE2EMefEline:
             payload.update({"primary_constraints": primary_constraints})
         if secondary_constraints:
             payload.update({"secondary_constraints": secondary_constraints})
-        api_url = KYTOS_API + "/mef_eline/v2/evc/"
+        api_url = KYTOS_API + "/mef_eline/v3/evc/"
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -92,7 +92,7 @@ class TestE2EMefEline:
 
     def update_evc(self, circuit_id: str, **kwargs) -> dict:
         """Update an EVC."""
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{circuit_id}"
+        api_url = f"{KYTOS_API}/mef_eline/v3/evc/{circuit_id}"
         response = requests.patch(api_url, json=kwargs)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -100,7 +100,7 @@ class TestE2EMefEline:
 
     def delete_evc(self, circuit_id) -> dict:
         """Delete an EVC."""
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{circuit_id}"
+        api_url = f"{KYTOS_API}/mef_eline/v3/evc/{circuit_id}"
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -108,7 +108,7 @@ class TestE2EMefEline:
 
     def test_002_update_uni(self):
         """Test when a uni is updated"""
-        api_url = KYTOS_API + "/mef_eline/v2/evc/"
+        api_url = KYTOS_API + "/mef_eline/v3/evc/"
         evc_id = self.create_evc(
             uni_a="00:00:00:00:00:00:00:01:1",
             uni_z="00:00:00:00:00:00:00:03:1",
@@ -156,7 +156,7 @@ class TestE2EMefEline:
             if v["ownership"] == "red":
                 red_link_ids.add(k)
 
-        api_url = KYTOS_API + "/mef_eline/v2/evc/"
+        api_url = KYTOS_API + "/mef_eline/v3/evc/"
         evc_id = self.create_evc(
             uni_a="00:00:00:00:00:00:00:01:1",
             uni_z="00:00:00:00:00:00:00:03:1",

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -84,7 +84,7 @@ class TestE2EMefEline:
             payload.update({"primary_constraints": primary_constraints})
         if secondary_constraints:
             payload.update({"secondary_constraints": secondary_constraints})
-        api_url = KYTOS_API + "/mef_eline/v3/evc/"
+        api_url = KYTOS_API + "/mef_eline/v2/evc/"
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -92,7 +92,7 @@ class TestE2EMefEline:
 
     def update_evc(self, circuit_id: str, **kwargs) -> dict:
         """Update an EVC."""
-        api_url = f"{KYTOS_API}/mef_eline/v3/evc/{circuit_id}"
+        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{circuit_id}"
         response = requests.patch(api_url, json=kwargs)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -100,7 +100,7 @@ class TestE2EMefEline:
 
     def delete_evc(self, circuit_id) -> dict:
         """Delete an EVC."""
-        api_url = f"{KYTOS_API}/mef_eline/v3/evc/{circuit_id}"
+        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{circuit_id}"
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -108,7 +108,7 @@ class TestE2EMefEline:
 
     def test_002_update_uni(self):
         """Test when a uni is updated"""
-        api_url = KYTOS_API + "/mef_eline/v3/evc/"
+        api_url = KYTOS_API + "/mef_eline/v2/evc/"
         evc_id = self.create_evc(
             uni_a="00:00:00:00:00:00:00:01:1",
             uni_z="00:00:00:00:00:00:00:03:1",
@@ -156,7 +156,7 @@ class TestE2EMefEline:
             if v["ownership"] == "red":
                 red_link_ids.add(k)
 
-        api_url = KYTOS_API + "/mef_eline/v3/evc/"
+        api_url = KYTOS_API + "/mef_eline/v2/evc/"
         evc_id = self.create_evc(
             uni_a="00:00:00:00:00:00:00:01:1",
             uni_z="00:00:00:00:00:00:00:03:1",

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -77,7 +77,7 @@ class TestE2EMefEline:
             "name": "Vlan_%s" % vlan_id,
             "enabled": True,
             "dynamic_backup_path": True,
-            "uni_a": {"interface_id": uni_a, "tag": {"tag_type": "vlan", "value": vlan_id}},
+            "uni_a": {"interface_id": uni_a, "tag": {"tag_type": 1, "value": vlan_id}},
             "uni_z": {"interface_id": uni_z, "tag": {"tag_type": "vlan", "value": vlan_id}},
         }
         if primary_constraints:
@@ -125,7 +125,7 @@ class TestE2EMefEline:
             evc_id,
             uni_z={
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             },
         )
         time.sleep(10)

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -77,8 +77,8 @@ class TestE2EMefEline:
             "name": "Vlan_%s" % vlan_id,
             "enabled": True,
             "dynamic_backup_path": True,
-            "uni_a": {"interface_id": uni_a, "tag": {"tag_type": 1, "value": vlan_id}},
-            "uni_z": {"interface_id": uni_z, "tag": {"tag_type": 1, "value": vlan_id}},
+            "uni_a": {"interface_id": uni_a, "tag": {"tag_type": "vlan", "value": vlan_id}},
+            "uni_z": {"interface_id": uni_z, "tag": {"tag_type": "vlan", "value": vlan_id}},
         }
         if primary_constraints:
             payload.update({"primary_constraints": primary_constraints})
@@ -125,7 +125,7 @@ class TestE2EMefEline:
             evc_id,
             uni_z={
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
         )
         time.sleep(10)

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -48,7 +48,7 @@ class TestE2ESDNTrace:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -56,7 +56,7 @@ class TestE2ESDNTrace:
 
     @staticmethod
     def get_evc(circuit_id):
-        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         response = requests.get(api_url+circuit_id)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -354,7 +354,7 @@ class TestE2ESDNTrace:
 
         # 4. redeploy evc and check again
         circuit_id = self.circuit['id']
-        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc'
         response = requests.patch(f"{api_url}/{circuit_id}/redeploy")
         assert response.status_code == 202, response.text
         time.sleep(10)
@@ -949,7 +949,7 @@ class TestE2ESDNTrace:
                     "interface_id": "00:00:00:00:00:00:00:03:3"
                 }
             }
-        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -41,11 +41,11 @@ class TestE2ESDNTrace:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": interface_a,
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             },
             "uni_z": {
                 "interface_id": interface_z,
-                "tag": {"tag_type": 1, "value": vlan_id}
+                "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
         api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -48,7 +48,7 @@ class TestE2ESDNTrace:
                 "tag": {"tag_type": "vlan", "value": vlan_id}
             }
         }
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -56,7 +56,7 @@ class TestE2ESDNTrace:
 
     @staticmethod
     def get_evc(circuit_id):
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
         response = requests.get(api_url+circuit_id)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -354,7 +354,7 @@ class TestE2ESDNTrace:
 
         # 4. redeploy evc and check again
         circuit_id = self.circuit['id']
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc'
+        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc'
         response = requests.patch(f"{api_url}/{circuit_id}/redeploy")
         assert response.status_code == 202, response.text
         time.sleep(10)
@@ -949,7 +949,7 @@ class TestE2ESDNTrace:
                     "interface_id": "00:00:00:00:00:00:00:03:3"
                 }
             }
-        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -41,7 +41,7 @@ class TestE2ESDNTrace:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": interface_a,
-                "tag": {"tag_type": "vlan", "value": vlan_id}
+                "tag": {"tag_type": 1, "value": vlan_id}
             },
             "uni_z": {
                 "interface_id": interface_z,

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -56,7 +56,7 @@ class TestE2EMaintenance:
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
                 "tag": {
-                    "tag_type": "vlan",
+                    "tag_type": 1,
                     "value": vlan_id
                 }
             },

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -49,14 +49,14 @@ class TestE2EMaintenance:
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": vlan_id
                 }
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:03:1",
                 "tag": {
-                    "tag_type": 1,
+                    "tag_type": "vlan",
                     "value": vlan_id
                 }
             },

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -34,7 +34,7 @@ class TestE2EMaintenance:
 
     @staticmethod
     def get_evc(circuit_id):
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.get(api_url+circuit_id)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -67,7 +67,7 @@ class TestE2EMaintenance:
                  "endpoint_b": {"id": "00:00:00:00:00:00:00:03:2"}}
             ],
         }
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/mef_eline/v3/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -34,7 +34,7 @@ class TestE2EMaintenance:
 
     @staticmethod
     def get_evc(circuit_id):
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url+circuit_id)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -67,7 +67,7 @@ class TestE2EMaintenance:
                  "endpoint_b": {"id": "00:00:00:00:00:00:00:03:2"}}
             ],
         }
-        api_url = KYTOS_API + '/mef_eline/v3/evc/'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         data = response.json()

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -312,7 +312,7 @@ class TestE2EOfMultiTable:
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": "vlan", "value": 100}
+                "tag": {"tag_type": 1, "value": 100}
             }
         }
 

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -112,7 +112,7 @@ class TestE2EOfMultiTable:
         }
 
         # Add circuit
-        api_url = f"{KYTOS_API}/mef_eline/v3/evc/"
+        api_url = f"{KYTOS_API}/mef_eline/v2/evc/"
         response = requests.post(api_url, json=evc)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -317,7 +317,7 @@ class TestE2EOfMultiTable:
         }
 
         # Add circuit
-        api_url = f"{KYTOS_API}/mef_eline/v3/evc/"
+        api_url = f"{KYTOS_API}/mef_eline/v2/evc/"
         response = requests.post(api_url, json=evc)
         assert response.status_code == 201, response.text
         data = response.json()

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -112,7 +112,7 @@ class TestE2EOfMultiTable:
         }
 
         # Add circuit
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/"
+        api_url = f"{KYTOS_API}/mef_eline/v3/evc/"
         response = requests.post(api_url, json=evc)
         assert response.status_code == 201, response.text
         data = response.json()
@@ -317,7 +317,7 @@ class TestE2EOfMultiTable:
         }
 
         # Add circuit
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/"
+        api_url = f"{KYTOS_API}/mef_eline/v3/evc/"
         response = requests.post(api_url, json=evc)
         assert response.status_code == 201, response.text
         data = response.json()

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -104,7 +104,7 @@ class TestE2EOfMultiTable:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:01:2"
@@ -308,11 +308,11 @@ class TestE2EOfMultiTable:
             "dynamic_backup_path": True,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             },
             "uni_z": {
                 "interface_id": "00:00:00:00:00:00:00:02:1",
-                "tag": {"tag_type": 1, "value": 100}
+                "tag": {"tag_type": "vlan", "value": 100}
             }
         }
 

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -113,7 +113,7 @@ class TestE2EKytosStats:
 
     def test_015_packet_count(self):
         """Test packet_count""" 
-
+        time.sleep(10)
         api_url = KYTOS_STATS + '/flow/stats'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
@@ -157,7 +157,7 @@ class TestE2EKytosStats:
 
     def test_025_packet_count_per_flow(self):
         """Test packet_count_per_flow""" 
-
+        time.sleep(10)
         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -217,7 +217,6 @@ class TestE2EKytosStats:
 
     def test_025_packet_count_per_flow(self):
         """Test packet_count_per_flow""" 
-        time.sleep(10)
         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text


### PR DESCRIPTION
Closes #260 

### Summary

Tag-type is changed to string
```
    VLAN = 1 to  'vlan'
    VLAN_QINQ = 2 to 'vlan_qinq'
    MPLS = 3 to 'mpls'
```

Update: This change is no longer necessary but it is better to be changing to a string instead of sticking with an integer type value.