### PR TITLE
chore: excluded telemetry_int from of_multi_table subscribed napps

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -12,6 +12,7 @@ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/SUBSCRIBED_NAPPS =.*/SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline"}/g' /var/lib/kytos/napps/kytos/of_multi_table/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates


### PR DESCRIPTION
Closes #263 

### Summary

- Excluded telemetry_int from of_multi_table subscribed napps. It's needed for https://github.com/kytos-ng/of_multi_table/pull/21


### End-to-End Tests

Test suite `test_e2e_60_of_multi_table` is passing with this branch and PR https://github.com/kytos-ng/of_multi_table/pull/21

```
$ ./kytos-init.sh
+ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+ sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
+ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/SUBSCRIBED_NAPPS =.*/SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline"}/g' /var/lib/kytos/napps/kytos/of_multi_table/settings.py
+ kytosd --help
+ sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
+ test -z 'tests -k of_multi_table'
+ test -z ''
+ RERUNS=2
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests -k of_multi_table --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items / 237 deselected / 5 selected
tests/test_e2e_60_of_multi_table.py .....                                [100%]
========== 5 passed, 237 deselected, 35 warnings in 301.03s (0:05:01) ==========
```
