### PR TITLE
chore: temporarily skip pathfinder test_10_undesired_link_and_max_path

### DIFF
--- a/tests/test_e2e_80_pathfinder.py
+++ b/tests/test_e2e_80_pathfinder.py
@@ -80,6 +80,7 @@ class TestE2EPathfinder:
             assert response.status_code == 201, response.text
         return links_metadata
 
+    @pytest.mark.skip(reason="issue 269 needs to be fixed/analyzed")
     @pytest.mark.parametrize(
         "undesired_link, expected_cost, max_paths, expected_paths",
         [


### PR DESCRIPTION
This doesn't cl0se issue #269, but until it's fully addressed/analyzed it'll skip this test case

### Local Tests

I confirmed it's skipping `test_10_undesired_link_and_max_path`

```
[vx kytos-end-to-end-tests]# python3 -m pytest --timeout=180 tests -k test_10_undesired_link_and_max_path
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.9.18, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/viniarck/repos/kytos-end-to-end-tests
plugins: anyio-3.6.2, timeout-2.2.0
timeout: 180.0s
timeout method: signal
timeout func_only: False
collected 254 items / 252 deselected / 2 selected                                                                                                                                       

tests/test_e2e_80_pathfinder.py ss                                                                                                                                                [100%]

=================================================================================== warnings summary ====================================================================================
../kytos/kytos/core/config.py:186
  /home/viniarck/repos/kytos/kytos/core/config.py:186: UserWarning: Unknown arguments: ['--timeout=180', 'tests', '-k', 'test_10_undesired_link_and_max_path']
    warnings.warn(f"Unknown arguments: {unknown}")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------------------------------------------------------------- start/stop times ------------------------------------------------------------------------------------
===================================================================== 2 skipped, 252 deselected, 1 warning in 0.25s =====================================================================
```

### End-to-End Tests

No need to run all the other test cases, it's just a skip