### PR TITLE
Added test for deleted links

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -659,7 +659,6 @@ class TestE2ETopology:
         response = requests.get(api_url)
         assert response.status_code == 200
         data = response.json()
-        print("DATA -> ", data)
         link_id = None
         for key, value in data['links'].items():
             if (value["endpoint_a"]["switch"] == switch_1 and 


### PR DESCRIPTION
Related PR [#179](https://github.com/kytos-ng/topology/pull/179)

### Summary

Added test for API endpoint that deletes link.

### Result
```
+ python3 -m pytest tests/ -k test_130_delete_link --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 255 items / 254 deselected / 1 selected

tests/test_e2e_05_topology.py .                                          [100%]
```
