### PR TITLE
chore: rm `flow_stats`

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -61,7 +61,6 @@ class TestE2EKytosServer:
                 ("kytos", "of_lldp"),
                 ("kytos", "of_multi_table"),
                 ('amlight', 'sdntrace'),
-                ('amlight', 'flow_stats'),
                 ('amlight', 'coloring'),
                 ('amlight', 'sdntrace_cp'),
                 ('amlight', 'kytos_stats'),


### PR DESCRIPTION
Related to https://github.com/amlight/kytos-docker/issues/31

### Summary

removed `flow_stats` from expected installed napps (up to this point we were maintaining both `kytos_stats` and `flow_stats`)

### End-to-End Tests

Results with this branch and docker's repo branch removing `flow_stats`:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 255 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 231 passed, 8 skipped, 9 xfailed, 7 xpassed, 1109 warnings in 12036.38s (3:20:36) =
```