### PR TITLE
Fixed requirements for enabling

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -238,6 +238,11 @@ class TestE2ETopology:
         supported by
             /api/kytos/topology/v3/interfaces on GET
         """
+        # Enable switch
+        dpid = '00:00:00:00:00:00:00:01'
+        api_url = f"{KYTOS_API}/topology/v3/switches/{dpid}/enable"
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
 
         # Make sure the interfaces are disabled
         api_url = KYTOS_API + '/topology/v3/interfaces'
@@ -267,8 +272,11 @@ class TestE2ETopology:
         supported by
             /api/kytos/topology/v3/switches on GET
         """
-
+        # Enable switch
         switch_id = "00:00:00:00:00:00:00:01"
+        api_url = f"{KYTOS_API}/topology/v3/switches/{switch_id}/enable"
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
 
         # Make sure all the interfaces belonging to the target switch are disabled
         api_url = KYTOS_API + '/topology/v3/switches'
@@ -300,7 +308,7 @@ class TestE2ETopology:
 
         self.restart()
 
-        # Make sure all the interfaces belonging to the target switch are enabled
+        # Make sure all the interfaces belonging to the target switch are disable
         api_url = KYTOS_API + '/topology/v3/switches'
         response = requests.get(api_url)
         data = response.json()
@@ -316,9 +324,14 @@ class TestE2ETopology:
             and
             /api/kytos/topology/v3/interfaces on GET
         """
-        interface_id = "00:00:00:00:00:00:00:01:4"
+        # Enable switch
+        switch_id = "00:00:00:00:00:00:00:01"
+        api_url = f"{KYTOS_API}/topology/v3/switches/{switch_id}/enable"
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
 
         # Enable the interface
+        interface_id = "00:00:00:00:00:00:00:01:4"
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/enable' % interface_id
         response = requests.post(api_url)
         assert response.status_code == 200, response.text
@@ -351,8 +364,11 @@ class TestE2ETopology:
             and
             /api/kytos/topology/v3/switches on GET
         """
-
+        # Enable switch
         switch_id = "00:00:00:00:00:00:00:01"
+        api_url = f"{KYTOS_API}/topology/v3/switches/{switch_id}/enable"
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
 
         # Enabling all the interfaces
         api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % switch_id

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -709,6 +709,67 @@ class TestE2ETopology:
         data = response.json()
         assert link_id not in data["links"]
 
+    def test_140_delete_switch(self):
+        """Test api/kytos/topology/v3/switches/{switch_id} on DELETE"""
+        # Enable the switches and ports first
+        for i in [1, 2]:
+            sw = "00:00:00:00:00:00:00:0%d" % i
+
+            api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
+            response = requests.post(api_url)
+            assert response.status_code == 201, response.text
+
+            api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw
+            response = requests.post(api_url)
+            assert response.status_code == 200, response.text
+
+        self.restart()
+        
+        # Switch is not disabled, 409
+        switch_1 = "00:00:00:00:00:00:00:01"
+        api_url = f'{KYTOS_API}/topology/v3/switches/{switch_1}'
+        response = requests.delete(api_url)
+        assert response.status_code == 409
+
+        # Switch have links, 409
+        api_url = f'{KYTOS_API}/topology/v3/switches/{switch_1}/disable'
+        response = requests.post(api_url)
+        assert response.status_code == 201
+
+        api_url = f'{KYTOS_API}/topology/v3/switches/{switch_1}'
+        response = requests.delete(api_url)
+        assert response.status_code == 409
+
+        # Get the link_id
+        switch_2 = "00:00:00:00:00:00:00:02"
+        api_url = KYTOS_API + '/topology/v3/links'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        link_id = None
+        for key, value in data['links'].items():
+            if (value["endpoint_a"]["switch"] == switch_1 and 
+                value["endpoint_b"]["switch"] == switch_2):
+                link_id = key
+                break
+        assert link_id
+
+        # Disabling link
+        self.net.net.configLinkStatus('s1', 's2', 'down')
+        api_url = KYTOS_API + f'/topology/v3/links/{link_id}/disable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+    
+        # Deleting link
+        api_url = KYTOS_API + f'/topology/v3/links/{link_id}'
+        response = requests.delete(api_url)
+        assert response.status_code == 200, response.text
+
+        # Delete switch, success
+        api_url = f'{KYTOS_API}/topology/v3/switches/{switch_1}'
+        response = requests.delete(api_url)
+        assert response.status_code == 200
+
     def test_200_switch_disabled_on_clean_start(self):
 
         switch_id = "00:00:00:00:00:00:00:01"

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -31,6 +31,7 @@ class TestE2EOfLLDP:
         data = response.json()
         switches = data.get("switches", {})
         for sw in switches.keys():
+            response = requests.post(KYTOS_API + '/topology/v3/switches/%s/enable' % sw)
             response = requests.post(KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw)
 
     @staticmethod


### PR DESCRIPTION
Closes #276 

### Summary

Depends on topology PR [#181](https://github.com/kytos-ng/topology/pull/181)
An interface cannot be enabled if its switch is disabled. Fixed

### Test results

```
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/ -k 'test_050_enabling_interface_persistent or test_060_enabling_and_disabling_all_interfaces_on_a_switch_persistent or test_070_disabling_interface_persistent or test_080_disabling_all_interfaces_on_a_switch_persistent or test_020_enable_of_lldp' --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 255 items / 250 deselected / 5 selected

tests/test_e2e_05_topology.py ....                                       [ 80%]
tests/test_e2e_30_of_lldp.py .                                           [100%]
```

```
+ python3 -m pytest tests/ -k test_140_delete_switch --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 256 items / 255 deselected / 1 selected

tests/test_e2e_05_topology.py .                                          [100%]
```
