### PR TITLE
Updated python

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -657,7 +657,7 @@ class TestE2ETopology:
         switch_2 = "00:00:00:00:00:00:00:02"
 
         # Enable the switches and ports first
-        for i in [1, 2]:
+        for i in [1, 2, 3]:
             sw = "00:00:00:00:00:00:00:0%d" % i
 
             api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
@@ -712,6 +712,7 @@ class TestE2ETopology:
     def test_140_delete_switch(self):
         """Test api/kytos/topology/v3/switches/{switch_id} on DELETE"""
         # Enable the switches and ports first
+        self.net.net.configLinkStatus('s1', 's2', 'up')
         self.restart(_clean_config=True, _enable_all=True)
 
         # Switch is not disabled, 409

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -343,4 +343,4 @@ class TestE2EMefEline:
         assert data["code"] == 400
         assert "The request body contains invalid API data" in data["description"]
         assert "not of type" in data["description"]
-        assert "for field uni_a/interface_id" in data["description"]
+        assert "1 is not of type 'string'" in data["description"]


### PR DESCRIPTION
Closes #293

### Summary

Minor changes due to python update
Depending in:
- [kytos PR](https://github.com/kytos-ng/kytos/pull/460)
- [kytos-docker PR](https://github.com/amlight/kytos-docker/pull/35)


### End-to-End Tests

```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.4.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 261 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ....................                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
