### PR TITLE
Added tests for interface deletion

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -819,6 +819,7 @@ class TestE2ETopology:
 
     def test_510_delete_interface(self):
         """Test api/kytos/topology/v3/interfaces/{interface_id} on DELETE"""
+        self.net.net.configLinkStatus('s1', 's3', 'up')
         for i in [1, 2, 3]:
             sw = "00:00:00:00:00:00:00:0%d" % i
 

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -816,3 +816,100 @@ class TestE2ETopology:
         data = response.json()
         for interface in data['interfaces']:
             assert data['interfaces'][interface]['enabled'] is True
+
+    def test_510_delete_interface(self):
+        """Test api/kytos/topology/v3/interfaces/{interface_id} on DELETE"""
+        for i in [1, 2, 3]:
+            sw = "00:00:00:00:00:00:00:0%d" % i
+
+            api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
+            response = requests.post(api_url)
+            assert response.status_code == 201, response.text
+
+            api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw
+            response = requests.post(api_url)
+            assert response.status_code == 200, response.text
+        self.restart()
+        switch_1 = "00:00:00:00:00:00:00:01"
+        switch_3 = "00:00:00:00:00:00:00:03"
+        intf_id = "00:00:00:00:00:00:00:01:4"
+        payload = {"flows": [
+            {
+                "priority": 10,
+                "instructions": [{
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "output", "port": 4}]
+                }]
+            }
+        ]}
+        api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_1
+        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert response.status_code == 202, response.text
+
+        # Interface is enabled
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id
+        response = requests.delete(api_url)
+        assert response.status_code == 409, response.text
+        data = response.json()
+
+        # Interface is active
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id + "/disable/"
+        response = requests.post(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id
+        response = requests.delete(api_url)
+        assert response.status_code == 409, response.text
+        data = response.json()
+
+        # Interface has a link
+        s1 = self.net.net.get('s1')
+        s1.detach('s1-eth4')
+
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id
+        response = requests.delete(api_url)
+        assert response.status_code == 409, response.text
+        data = response.json()
+
+        # Installed flows related to the interface
+        api_url = KYTOS_API + '/topology/v3/links'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        link_id = None
+        for key, value in data['links'].items():
+            if (value["endpoint_a"]["switch"] == switch_1 and 
+                value["endpoint_b"]["switch"] == switch_3):
+                link_id = key
+                break
+        assert link_id
+        self.net.net.configLinkStatus('s1', 's2', 'down')
+        api_url = KYTOS_API + f'/topology/v3/links/{link_id}/disable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+        api_url = KYTOS_API + f'/topology/v3/links/{link_id}'
+        response = requests.delete(api_url)
+        assert response.status_code == 200, response.text
+
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id
+        response = requests.delete(api_url)
+        assert response.status_code == 409, response.text
+        data = response.json()
+
+        # Interface succesfully deleted
+        payload = {
+            "force": True,
+            "flows": [
+                {
+                    "priority": 10
+                }
+            ]
+        }
+        api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_1
+        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert response.status_code == 202, response.text
+
+        api_url = KYTOS_API + '/topology/v3/interfaces/' + intf_id
+        response = requests.delete(api_url)
+        assert response.status_code == 200, response.text


### PR DESCRIPTION
Closes #297

### Summary

Added test for interface deletion.

### Local Tests

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_05_topology.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 21 items

tests/test_e2e_05_topology.py .....................                      [100%]

```
