### PR TITLE
Isolated last topology test

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -919,22 +919,3 @@ class TestE2ETopology:
         assert response.status_code == 200, response.text
         data = response.json()
         assert not intf_id in data["interfaces"]
-
-    def test_515_delete_interface_automatically(self):
-        """Test interface removal after logical deletion"""
-        intf_id = "00:00:00:00:00:00:00:01:4"
-        api_url = KYTOS_API + f'/topology/v3/interfaces'
-        response = requests.get(api_url)
-        assert response.status_code == 200, response.text
-        data = response.json()
-        assert intf_id in data["interfaces"]
-
-        s1 = self.net.net.get('s1')
-        s1.detach('s1-eth4')
-        time.sleep(5)
-
-        api_url = KYTOS_API + f'/topology/v3/interfaces'
-        response = requests.get(api_url)
-        assert response.status_code == 200, response.text
-        data = response.json()
-        assert not intf_id in data["interfaces"]

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -1,0 +1,49 @@
+import requests
+from tests.helpers import NetworkTest
+import time
+
+CONTROLLER = '127.0.0.1'
+KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
+
+class TestE2ETopology:
+    net = None
+
+    def setup_method(self, method):
+        """
+        It is called at the beginning of every class method execution
+        """
+        # Start the controller setting an environment in
+        # which all elements are disabled in a clean setting
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
+        time.sleep(10)
+
+    @classmethod
+    def setup_class(cls):
+        cls.net = NetworkTest(CONTROLLER)
+        cls.net.start()
+        cls.net.wait_switches_connect()
+        time.sleep(10)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.net.stop()
+
+    def test_010_delete_interface_automatically(self):
+        """Test interface removal after logical deletion"""
+        intf_id = "00:00:00:00:00:00:00:02:1"
+        api_url = KYTOS_API + f'/topology/v3/interfaces'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert intf_id in data["interfaces"]
+
+        s2 = self.net.net.get('s2')
+        s2.detach('s2-eth1')
+        time.sleep(5)
+
+        api_url = KYTOS_API + f'/topology/v3/interfaces'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert not intf_id in data["interfaces"]


### PR DESCRIPTION
Closes #299

### Summary

Isolated last test so it not affected by other tests

### Local Tests

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_06_topology.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 1 item

tests/test_e2e_06_topology.py .                                          [100%]
```

```
+ python3 -m pytest tests/test_e2e_05_topology.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 21 items

tests/test_e2e_05_topology.py .....................                      [100%]
```
