### PR TITLE
Updated to mongo 7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,11 @@ and can be done by activating the venv and installing the dependencies with the 
 You can install dependencies on an existing kytosd environment or use the same one you created both on docker and
 locally, but other unexpected surprises may arise, such as when you introduce new kytos core dependencies.
 
+For Debian 12 bookworm the packages ``orphan-sysvinit-scripts`` and ``rsyslog`` need to be installed. The following 
+command will sufice::
+
+  $ sudo apt-get update && apt-get install -y orphan-sysvinit-scripts rsyslog
+
 ---
 
 You can start running tests locally by adding the mongoLT (Local Test) hosts with the add-etc-local-hosts.sh bash script as follows::

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   mongo-setup:
     container_name: mongo-test-rs-init
-    image: mongo:5.0
+    image: mongo:7.0
     restart: on-failure
     volumes:
       - ./scripts:/scripts
@@ -20,7 +20,7 @@ services:
       - mongo3LT
   mongo1LT:
     container_name: mongo1LT
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27037:27037
     restart: always
@@ -30,14 +30,14 @@ services:
       - mongo3LT
   mongo2LT:
     container_name: mongo2LT
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27038:27038
     restart: always
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27038" ]
   mongo3LT:
     container_name: mongo3LT
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27039:27039
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   kytos:
     image: amlight/kytos:latest
@@ -18,7 +17,7 @@ services:
       - mongo-setup
   mongo-setup:
     container_name: mongo-test-rs-init
-    image: mongo:5.0
+    image: mongo:7.0
     restart: on-failure
     volumes:
       - ./scripts:/scripts
@@ -36,7 +35,7 @@ services:
       - mongo3t
   mongo1t:
     container_name: mongo1t
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27027:27027
     restart: always
@@ -46,14 +45,14 @@ services:
       - mongo3t
   mongo2t:
     container_name: mongo2t
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27028:27028
     restart: always
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27028" ]
   mongo3t:
     container_name: mongo3t
-    image: mongo:5.0
+    image: mongo:7.0
     ports:
       - 27029:27029
     restart: always

--- a/requirements/requirements-local.txt
+++ b/requirements/requirements-local.txt
@@ -1,6 +1,6 @@
-pytest-timeout==2.1.0
-pytest==7.2.1
-pytest-rerunfailures==10.2
-mock==4.0.3
-pymongo==4.1.0
-requests==2.27.0
+pytest-timeout==2.2.0
+pytest==8.1.1
+pytest-rerunfailures==13.0
+mock==5.1.0
+pymongo==4.6.2
+requests==2.31.0


### PR DESCRIPTION
Closes #303

### Summary

Updated the requirements from the local tests.
Updated to MongoDB 7.0

### Local Tests

Before updating to 7.0, be sure to download the latest MongoDB package.
To run End-to-End-tests, the containers must be stopped and deleted. If e2e tests had been executed before the existing containers would be `kytos-end-to-end-tests-kytos-1`, `mongo-test-rs-init`, `mongo1t`, `mongo2t` and `mongo3t`:

```
CONTAINER ID   IMAGE                 COMMAND                  CREATED       STATUS                   PORTS                                                      NAMES
34ba9c958311   amlight/kytos:aldo2   "/docker-entrypoint.…"   3 hours ago   Exited (0) 3 hours ago                                                              kytos-end-to-end-tests-kytos-1
c6a6d07badef   mongo:7.0             "/scripts/rs-init.sh"    3 hours ago   Exited (0) 3 hours ago                                                              mongo-test-rs-init
1fdee082d3b0   mongo:7.0             "/usr/bin/mongod --b…"   3 hours ago   Up 33 seconds            27017/tcp, 0.0.0.0:27027->27027/tcp, :::27027->27027/tcp   mongo1t
3d42f39d4aef   mongo:7.0             "/usr/bin/mongod --b…"   3 hours ago   Up 33 seconds            27017/tcp, 0.0.0.0:27029->27029/tcp, :::27029->27029/tcp   mongo3t
00f211bfd7dc   mongo:7.0             "/usr/bin/mongod --b…"   3 hours ago   Up 33 seconds            27017/tcp, 0.0.0.0:27028->27028/tcp, :::27028->27028/tcp   mongo2t
```
To show containers: `docker ps -a`
To stop a container: `docker stop $CONTAINER_ID`
To delete a container: `docker rm $CONTAINER_ID`

Discrepancies:
- Sometimes when running the 7.0 version for the first time the authorization fails. A rerun solves it.

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 263 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 68%]
tests/test_e2e_30_of_lldp.py ....                                        [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```