### PR TITLE
Added versioning to sdntrace requests

### DIFF
--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -146,7 +146,7 @@ class TestE2ESDNTrace:
         wait_count = 0
         while wait_count < timeout:
             try:
-                api_url = KYTOS_API + '/amlight/sdntrace/trace'
+                api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
                 response = requests.get(f"{api_url}/{trace_id}")
                 data = response.json()
                 assert data["result"][-1]["reason"] == "done"
@@ -186,7 +186,7 @@ class TestE2ESDNTrace:
             }
         }
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -233,7 +233,7 @@ class TestE2ESDNTrace:
             }
         }
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -332,7 +332,7 @@ class TestE2ESDNTrace:
             }
         }
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload_2)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -379,7 +379,7 @@ class TestE2ESDNTrace:
         ]
         assert expected == actual, f"Expected {expected}. Actual: {actual}"
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload_2)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -819,7 +819,7 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["port"] == 1
         assert list_results[0][-1]["type"] == "last"
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload[0])
         assert response.status_code == 200, response.text
         data = response.json()
@@ -863,7 +863,7 @@ class TestE2ESDNTrace:
         assert list_results[0][0]["port"] == 1
         assert list_results[0][-1]["type"] == "last"
 
-        api_url = KYTOS_API + '/amlight/sdntrace/trace'
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
         response = requests.put(api_url, json=payload[0])
         assert response.status_code == 200, response.text
         data = response.json()


### PR DESCRIPTION
Closes #306

### Summary

Depends on this [PR](https://github.com/kytos-ng/sdntrace/pull/78)
Added versioning to `sdntrace` API requests

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_40_sdntrace.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 14 items

tests/test_e2e_40_sdntrace.py ..............                             [100%]

=============================== warnings summary ===============================
```
