### PR TITLE
Added more time to setup Amlight topology

### DIFF
--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -17,7 +17,7 @@ class TestE2ETopology:
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=True)
         self.net.wait_switches_connect()
-        time.sleep(10)
+        time.sleep(20)
 
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Closes #309 
Closes #305 
Closes #310 

### Summary

As pointed out by Italo, amlight topology did not have enough time to setup links. The time was increased from 10 to 20

### Local Tests
Tested multiple times in [gitlab](https://gitlab.ampath.net/amlight/kytos-end-to-end-tester/-/jobs/67518)

### End-to-End Tests
N/A