### PR TITLE
Updated payload for EVC patching

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -422,7 +422,7 @@ class TestE2EMefEline:
 
     def test_040_disable_circuit_should_remove_openflow_rules(self):
         # let's suppose that xyz is the circuit id previously created
-        # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v2/evc/xyz
+        # curl -X PATCH -H "Content-Type: application/json" -d '{"enabled": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v2/evc/xyz
         payload = {
             "name": "Vlan125_Test_evc1",
             "enabled": True,
@@ -450,7 +450,7 @@ class TestE2EMefEline:
         assert data['enabled'] is True
 
         # It disables the circuit
-        payload = {"enable": False}
+        payload = {"enabled": False}
         response = requests.patch(api_url + evc1, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 200, response.text
         time.sleep(10)

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -79,7 +79,7 @@ class TestE2EMefEline:
     # Disable circuit
     def _disable_circuit(self, circuit_id):
         payload = {
-            "enable": False,
+            "enabled": False,
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.patch(api_url, json=payload)


### PR DESCRIPTION
Closes #316 

### Summary

Based on `mef_eline` PR [#475](https://github.com/kytos-ng/mef_eline/pull/475)
Updated EVC patching

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 265 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  9%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 44%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py .                                         [ 47%]
tests/test_e2e_20_flow_manager.py .....................                  [ 55%]
tests/test_e2e_21_flow_manager.py ...                                    [ 56%]
tests/test_e2e_22_flow_manager.py ...............                        [ 62%]
tests/test_e2e_23_flow_manager.py ..............                         [ 67%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 69%]
tests/test_e2e_31_of_lldp.py ...                                         [ 70%]
tests/test_e2e_32_of_lldp.py ...                                         [ 71%]
tests/test_e2e_40_sdntrace.py ................                           [ 77%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 80%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```
Because `test_010_disable_of_lldp` from `test_e2e_30_of_lldp.py` failed:
```
+ python3 -m pytest tests/ -k test_010_disable_of_lldp --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 265 items / 264 deselected / 1 selected

tests/test_e2e_30_of_lldp.py .                                           [100%]
```