### PR TITLE
fix: enhanced TestE2EKytosStats flaky test cases

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -217,6 +217,9 @@ class TestE2EKytosStats:
 
     def test_025_packet_count_per_flow(self):
         """Test packet_count_per_flow""" 
+        # give enough time for stats gathering (of_core.STATS_INTERVAL)
+        time.sleep(10)
+
         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'  
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
@@ -229,12 +232,14 @@ class TestE2EKytosStats:
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['packet_count']
-            assert info_flow['packet_counter'] == count
-            assert info_flow['packet_per_second'] == count/data_flow[flow_id]['duration_sec']
+            assert info_flow['packet_counter'] >= count
+            assert info_flow['packet_per_second'] >= count/data_flow[flow_id]['duration_sec']
 
 
     def test_030_bytes_count_per_flow(self):
         """Test bytes_count_per_flow""" 
+        # give enough time for stats gathering (of_core.STATS_INTERVAL)
+        time.sleep(10)
 
         api_url = KYTOS_STATS + '/flow/stats?dpid=00:00:00:00:00:00:00:01'  
         response = requests.get(api_url)
@@ -248,8 +253,8 @@ class TestE2EKytosStats:
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['byte_count']
-            assert info_flow['bytes_counter'] == count
-            assert info_flow['bits_per_second'] == 8 * count/data_flow[flow_id]['duration_sec']
+            assert info_flow['bytes_counter'] >= count
+            assert info_flow['bits_per_second'] >= 8 * count/data_flow[flow_id]['duration_sec']
 
     def test_035_table_fields_update(self):
         """Test fields are updating on table 0.


### PR DESCRIPTION
Closes #325 

### Summary

- Enhanced both `test_025_packet_count_per_flow` and `test_030_bytes_count_per_flow` test cases to be less flaky by adding an extra time sleep and refactoring the data comparison to be less strict. 

### Local Tests

I ran these two test cases 3 times on the CI:

```
+ python3 -m pytest tests/test_e2e_70_kytos_stats.py -k per_flow --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 8 items / 6 deselected / 2 selected
tests/test_e2e_70_kytos_stats.py ..                                      [100%]
------------------------------- start/stop times -------------------------------
=========== 2 passed, 6 deselected, 34 warnings in [128](https://gitlab.ampath.net/amlight/kytos-end-to-end-tester/-/jobs/72761#L128).29s (0:02:08) ===========
```

### End-to-End Tests

See local tests
