### PR TITLE
Correcting primary_path test

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1042,23 +1042,24 @@ class TestE2EMefEline:
         data = response.json()
         assert expected_err in data["description"]
 
-    """The EVC is returning active=False"""
-    @pytest.mark.xfail
     def test_130_patch_primary_path(self):
+        """Patch EVC with primary_path and verify that it is applied to
+         current_path."""
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
             "name": "my evc1",
             "enabled": True,
+            "dynamic_backup_path": False,
             "uni_a": {
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "interface_id": "00:00:00:00:00:00:00:03:1"
+                "interface_id": "00:00:00:00:00:00:00:02:1"
             },
             "primary_path": [
-                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:4"},
-                 "endpoint_b": {"id": "00:00:00:00:00:00:00:03:2"}}
+                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"}}
             ]
         }
         response = requests.post(api_url, data=json.dumps(payload1),
@@ -1068,8 +1069,8 @@ class TestE2EMefEline:
         time.sleep(10)
         payload2 = {
             "primary_path": [
-                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
-                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"}},
+                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:4"},
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:03:3"}},
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:02:3"},
                  "endpoint_b": {"id": "00:00:00:00:00:00:00:03:2"}}
             ]
@@ -1086,12 +1087,17 @@ class TestE2EMefEline:
         data = response.json()
 
         paths = []
-        for _path in data['primary_path']:
+        for _path in data['current_path']:
             paths.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
                           "endpoint_b": {"id": _path['endpoint_b']['id']}})
 
         assert paths == payload2["primary_path"]
         assert data['active'] is True
+
+        response = requests.get(api_url + evc1)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["primary_path"] == payload2["primary_path"]
 
     def test_135_patch_backup_path(self):
 

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1097,7 +1097,11 @@ class TestE2EMefEline:
         response = requests.get(api_url + evc1)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert data["primary_path"] == payload2["primary_path"]
+        paths = []
+        for _path in data['primary_path']:
+            paths.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
+                          "endpoint_b": {"id": _path['endpoint_b']['id']}})
+        assert paths == payload2["primary_path"]
 
     def test_135_patch_backup_path(self):
 


### PR DESCRIPTION
Closes #332

### Summary

Using old test to test `primary_path` deployment into `current_path`

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ -k test_130_patch_primary_path --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items / 266 deselected / 1 selected

tests/test_e2e_10_mef_eline.py .                                         [100%]
```
