### PR TITLE
augmented e2e to cover status and status_reason for liveness

### DIFF
--- a/tests/test_e2e_31_of_lldp.py
+++ b/tests/test_e2e_31_of_lldp.py
@@ -228,6 +228,8 @@ class TestE2EOfLLDP:
         assert data["links"]
         metadata = data["links"][link_id]["metadata"]
         assert metadata["liveness_status"] == "down", metadata
+        assert data["links"][link_id]["status"] == "DOWN"
+        assert data["links"][link_id]["status_reason"] == ["liveness"]
 
         s2 = self.net.net.get("s2")
         flow_entry = "cookie=0xdd00000000000000/-1"


### PR DESCRIPTION
Related to https://github.com/kytos-ng/of_lldp/pull/111

### Summary

Augmented e2e to cover status and status_reason for livenesss

### Local Tests

with this branch and the new e2e related test:

```
+ python3 -m pytest tests/ -k test_005_liveness_goes_down --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 267 items / 266 deselected / 1 selected
tests/test_e2e_31_of_lldp.py .                                           [100%]
------------------------------- start/stop times -------------------------------
========== 1 passed, 266 deselected, 35 warnings in 91.46s (0:01:31) ===========
```

