### PR TITLE
e2e test cov for UNIs activation cases

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -2017,8 +2017,8 @@ class TestE2EMefEline:
 
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
         # shutdown NNIs and UNI a
         self.net.net.configLinkStatus("s1", "s2", "down")
@@ -2028,17 +2028,17 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up only UNI, EVC should still remain not active
         self.net.net.configLinkStatus("s1", "h11", "up")
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
+        assert not data["active"]
         # pathfinder won't find a new path since UNI is part of the graph
-        assert not data[evc1]["current_path"]
+        assert not data["current_path"]
 
         # bring up the rest of NNIs, now it should be activated
         self.net.net.configLinkStatus("s1", "s2", "up")
@@ -2046,24 +2046,24 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
         # shutdown UNI a, now it should deactivate again
         self.net.net.configLinkStatus("s1", "h11", "down")
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert not data["active"]
+        assert data["current_path"]
 
         # bring up UNI a, now it should activate
         self.net.net.configLinkStatus("s1", "h11", "up")
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
         # shutdown NNIs and UNI a
         self.net.net.configLinkStatus("s1", "s2", "down")
@@ -2073,30 +2073,28 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up a NNI, it shouldn't activate yet since UNI is still down
         self.net.net.configLinkStatus("s1", "s2", "up")
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up UNI a, now it should activate, and result in new deployment
         self.net.net.configLinkStatus("s1", "h11", "up")
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
     def test_301_inter_evc_static_uni_status(self):
         """Test UNI status for a dynamic inter EVC."""
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        evc1 = self.create_evc(100)
-
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -2104,11 +2102,17 @@ class TestE2EMefEline:
                 "interface_id": "00:00:00:00:00:00:00:01:1",
             },
             "uni_z": {
-                "interface_id": "00:00:00:00:00:00:00:02:1"
+                "interface_id": "00:00:00:00:00:00:00:03:1"
             },
             "primary_path": [
-                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
-                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:3"}}
+                {
+                    "endpoint_a": {
+                        "id": "00:00:00:00:00:00:00:01:4"
+                    },
+                    "endpoint_b": {
+                        "id": "00:00:00:00:00:00:00:03:3"
+                    }
+                }
             ]
         }
 
@@ -2122,19 +2126,19 @@ class TestE2EMefEline:
 
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
         # shutdown UNI a, it should deactivate
         self.net.net.configLinkStatus('s1', 'h11', 'down')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert not data["active"]
+        assert data["current_path"]
 
         # shutdown NNI too, current_path should be gone too
-        self.net.net.configLinkStatus('s1', 's2', 'down')
+        self.net.net.configLinkStatus('s3', 's1', 'down')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
@@ -2146,20 +2150,20 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up NNI, it should activate
-        self.net.net.configLinkStatus('s1', 's2', 'up')
+        self.net.net.configLinkStatus('s3', 's1', 'up')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]
 
         # shutdown again both
         self.net.net.configLinkStatus('s1', 'h11', 'down')
-        self.net.net.configLinkStatus('s1', 's2', 'down')
+        self.net.net.configLinkStatus('s3', 's1', 'down')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
@@ -2167,17 +2171,17 @@ class TestE2EMefEline:
         assert not data[evc1]["current_path"]
 
         # bring up NNI, it shouldn't activate since UNI is still down
-        self.net.net.configLinkStatus('s1', 's2', 'up')
+        self.net.net.configLinkStatus('s3', 's1', 'up')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert not data["active"]
+        assert data["current_path"]
 
         # bring up UNI a, it should activate
         self.net.net.configLinkStatus('s1', 'h11', 'up')
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data[evc1]["active"]
-        assert data[evc1]["current_path"]
+        assert data["active"]
+        assert data["current_path"]

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -2119,7 +2119,7 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert r.status_code == 201, r.text
-        data = response.json()
+        data = r.json()
         evc1 = data["circuit_id"]
 
         time.sleep(10)
@@ -2142,8 +2142,8 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up UNI a, it shouldn't activate yet, since NNI is down
         self.net.net.configLinkStatus('s1', 'h11', 'up')
@@ -2167,8 +2167,8 @@ class TestE2EMefEline:
         time.sleep(10)
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert not data[evc1]["active"]
-        assert not data[evc1]["current_path"]
+        assert not data["active"]
+        assert not data["current_path"]
 
         # bring up NNI, it shouldn't activate since UNI is still down
         self.net.net.configLinkStatus('s3', 's1', 'up')

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -2008,3 +2008,176 @@ class TestE2EMefEline:
         data = response.json()
         assert "test" in data[evc_1_id]["metadata"]
         assert "test" in data[evc_2_id]["metadata"]
+
+    def test_300_inter_evc_dynamic_uni_status(self):
+        """Test UNI status for a dynamic inter EVC."""
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        evc1 = self.create_evc(100)
+        time.sleep(10)
+
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown NNIs and UNI a
+        self.net.net.configLinkStatus("s1", "s2", "down")
+        self.net.net.configLinkStatus("s3", "s1", "down")
+        self.net.net.configLinkStatus("s1", "h11", "down")
+
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up only UNI, EVC should still remain not active
+        self.net.net.configLinkStatus("s1", "h11", "up")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        # pathfinder won't find a new path since UNI is part of the graph
+        assert not data[evc1]["current_path"]
+
+        # bring up the rest of NNIs, now it should be activated
+        self.net.net.configLinkStatus("s1", "s2", "up")
+        self.net.net.configLinkStatus("s3", "s1", "up")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown UNI a, now it should deactivate again
+        self.net.net.configLinkStatus("s1", "h11", "down")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # bring up UNI a, now it should activate
+        self.net.net.configLinkStatus("s1", "h11", "up")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown NNIs and UNI a
+        self.net.net.configLinkStatus("s1", "s2", "down")
+        self.net.net.configLinkStatus("s3", "s1", "down")
+        self.net.net.configLinkStatus("s1", "h11", "down")
+
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up a NNI, it shouldn't activate yet since UNI is still down
+        self.net.net.configLinkStatus("s1", "s2", "up")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up UNI a, now it should activate, and result in new deployment
+        self.net.net.configLinkStatus("s1", "h11", "up")
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+    def test_301_inter_evc_static_uni_status(self):
+        """Test UNI status for a dynamic inter EVC."""
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        evc1 = self.create_evc(100)
+
+        payload = {
+            "name": "my evc1",
+            "enabled": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:1"
+            },
+            "primary_path": [
+                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:3"}}
+            ]
+        }
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert r.status_code == 201, r.text
+        data = response.json()
+        evc1 = data["circuit_id"]
+
+        time.sleep(10)
+
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown UNI a, it should deactivate
+        self.net.net.configLinkStatus('s1', 'h11', 'down')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown NNI too, current_path should be gone too
+        self.net.net.configLinkStatus('s1', 's2', 'down')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up UNI a, it shouldn't activate yet, since NNI is down
+        self.net.net.configLinkStatus('s1', 'h11', 'up')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up NNI, it should activate
+        self.net.net.configLinkStatus('s1', 's2', 'up')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # shutdown again both
+        self.net.net.configLinkStatus('s1', 'h11', 'down')
+        self.net.net.configLinkStatus('s1', 's2', 'down')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert not data[evc1]["current_path"]
+
+        # bring up NNI, it shouldn't activate since UNI is still down
+        self.net.net.configLinkStatus('s1', 's2', 'up')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert not data[evc1]["active"]
+        assert data[evc1]["current_path"]
+
+        # bring up UNI a, it should activate
+        self.net.net.configLinkStatus('s1', 'h11', 'up')
+        time.sleep(10)
+        response = requests.get(api_url + evc1)
+        data = response.json()
+        assert data[evc1]["active"]
+        assert data[evc1]["current_path"]


### PR DESCRIPTION
Closes #335 

### Summary

- e2e test cov for UNIs activation cases
- This is using PR https://github.com/kytos-ng/mef_eline/pull/573

### Local Tests

```
+ python3 -m pytest tests/test_e2e_10_mef_eline.py -k uni_status --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 42 items / 40 deselected / 2 selected
tests/test_e2e_10_mef_eline.py ..                                        [100%]
------------------------------- start/stop times -------------------------------
========== 2 passed, 40 deselected, 34 warnings in 275.83s (0:04:35) ===========
```

### End-to-End Tests

- mef_eline test suites

```
+ python3 -m pytest tests/ -k mef_eline --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 273 items / 166 deselected / 107 selected
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 38%]
.                                                                        [ 39%]
tests/test_e2e_11_mef_eline.py ......                                    [ 44%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 52%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 90%]
.                                                                        [ 91%]
tests/test_e2e_14_mef_eline.py x                                         [ 92%]
tests/test_e2e_15_mef_eline.py .....                                     [ 97%]
tests/test_e2e_16_mef_eline.py ..                                        [ 99%]
tests/test_e2e_60_of_multi_table.py .                                    [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 86 passed, 6 skipped, 166 deselected, 8 xfailed, 7 xpassed, 407 warnings in 4672.35s (1:17:52) =
```