### PR TITLE
Added test for link_up, static and empty path

### DIFF
--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -307,6 +307,7 @@ class TestE2EMefEline:
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         primary_path = evc_content['primary_path']
+        assert current_path and primary_path
         assert len(current_path) == len(primary_path)
         for current, primary in zip(current_path, primary_path):
             assert current["endpoint_a"]["id"] == primary["endpoint_a"]["id"]
@@ -329,6 +330,7 @@ class TestE2EMefEline:
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         backup_path = evc_content['backup_path']
+        assert current_path and backup_path
         assert len(current_path) == len(backup_path)
         for current, backup in zip(current_path, backup_path):
             assert current["endpoint_a"]["id"] == backup["endpoint_a"]["id"]


### PR DESCRIPTION
Closes #341 

### Summary

Added test for case in issue. The only difference being that `sudo ifconfig s1-eth1 down` was replaced for a link. This link is the UNI of the EVC tested.

### Local Tests
N/A

### End-to-End Tests
```
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/test_e2e_14_mef_eline.py -k test_025_uni_link_up_static_path --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 5 items / 4 deselected / 1 selected

tests/test_e2e_14_mef_eline.py .                                         [100%]
```

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 277 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 43%]
.                                                                        [ 44%]
tests/test_e2e_14_mef_eline.py x....                                     [ 45%]
tests/test_e2e_15_mef_eline.py .....                                     [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_20_flow_manager.py ..........................             [ 57%]
tests/test_e2e_21_flow_manager.py ...                                    [ 58%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]

```
