### PR TITLE
Added comparison for path expected value.

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1316,12 +1316,44 @@ class TestE2EMefEline:
         response = requests.get(api_url + evc1)
         data = response.json()
 
+        assert data['active'] is False
+        assert data['enabled'] is True
+        assert not data['current_path']
+
+        current_path = []
+        for _path in data['current_path']:
+            current_path.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
+                          "endpoint_b": {"id": _path['endpoint_b']['id']}})
+    
+        expected_path = []
+
+        assert current_path == expected_path
+
         # Command to up/down links to test if back-up path is taken
         self.net.net.configLinkStatus('s1', 's2', 'up')
 
-        assert data['active'] is False
+        time.sleep(10)
+
+        response = requests.get(api_url + evc1)
+        data = response.json()
+
+        assert data['active'] is True
         assert data['enabled'] is True
-        assert data['current_path'] == []
+        assert data['current_path']
+
+        expected_path = [
+            {
+                "endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"}
+            }
+        ]
+
+        current_path = []
+        for _path in data['current_path']:
+            current_path.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
+                          "endpoint_b": {"id": _path['endpoint_b']['id']}})
+
+        assert current_path == expected_path
 
     def test_155_removing_evc_metadata_persistent(self):
         """


### PR DESCRIPTION
### Summary

Modifies existing test to compare path values, before and after a link up on a static path with no dynamic backup.

### End-to-End Tests

Ran with kytos-ng/mef_eline#632.

Here are the E2E results:

```
+ python3 -m pytest tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_150_current_path_value_given_dynamic_backup_path_and_empty_primary_conditions
=================================================================== test session starts ===================================================================
platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ktmi/Documents/kytos-project/kytos-end-to-end-tests
plugins: anyio-4.3.0
collected 1 item                                                                                                                                          

tests/test_e2e_10_mef_eline.py .                                                                                                                    [100%]

==================================================================== warnings summary =====================================================================
tests/test_e2e_10_mef_eline.py: 17 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1106: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_10_mef_eline.py: 17 warnings
  /home/ktmi/Documents/kytos-project/.venv/lib/python3.11/site-packages/mininet/node.py:1107: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------- start/stop times ---------------------------------------------------------------------
======================================================== 1 passed, 34 warnings in 78.75s (0:01:18) ========================================================
```