### PR TITLE
Adjusted tests for change in default tag range

### DIFF
--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -248,8 +248,8 @@ class TestE2EMefEline:
         data = response.json()
         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
-        expected = [[1, 99], [101, 3798], [3800, 4095]]
-        expected_tr = [[1, 4095]]
+        expected = [[1, 99], [101, 3798], [3800, 4094]]
+        expected_tr = [[1, 4094]]
         assert actual == expected
         assert actual_tr == expected_tr
         actual = data["00:00:00:00:00:00:00:02:2"]["available_tags"]["vlan"]
@@ -281,20 +281,20 @@ class TestE2EMefEline:
         response = requests.get(topo_url)
         data = response.json()
         actual = data["00:00:00:00:00:00:00:02:2"]["available_tags"]["vlan"]
-        expected = [[1, 99], [101, 199], [201, 3798], [3800, 4095]]
+        expected = [[1, 99], [101, 199], [201, 3798], [3800, 4094]]
         actual_tr = data["00:00:00:00:00:00:00:02:2"]["tag_ranges"]["vlan"]
-        expected_tr = [[1, 4095]]
+        expected_tr = [[1, 4094]]
         assert actual == expected
         assert actual_tr == expected_tr
 
         actual = data["00:00:00:00:00:00:00:01:1"]["available_tags"]["vlan"]
-        expected = [[1, 199], [201, 3798], [3800, 4095]]
+        expected = [[1, 199], [201, 3798], [3800, 4094]]
         actual_tr = data["00:00:00:00:00:00:00:01:1"]["tag_ranges"]["vlan"]
         assert actual == expected
         assert actual_tr == expected_tr
 
         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
-        expected = [[1, 99], [101, 3798], [3800, 4095]]
+        expected = [[1, 99], [101, 3798], [3800, 4094]]
         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
         assert actual == expected
         assert actual_tr == expected_tr
@@ -316,13 +316,13 @@ class TestE2EMefEline:
         response = requests.get(topo_url)
         data = response.json()
         actual = data["00:00:00:00:00:00:00:02:1"]["available_tags"]["vlan"]
-        expected = [[1, 99], [101, 3798], [3800, 4095]]
+        expected = [[1, 99], [101, 3798], [3800, 4094]]
         actual_tr = data["00:00:00:00:00:00:00:02:1"]["tag_ranges"]["vlan"]
         assert actual == expected
         assert actual_tr == expected_tr
 
         actual = data["00:00:00:00:00:00:00:02:2"]["available_tags"]["vlan"]
-        expected = [[1, 99], [101, 199], [201, 3798], [3800, 4095]]
+        expected = [[1, 99], [101, 199], [201, 3798], [3800, 4094]]
         actual_tr = data["00:00:00:00:00:00:00:02:2"]["tag_ranges"]["vlan"]
         assert actual == expected
         assert actual_tr == expected_tr
@@ -352,7 +352,7 @@ class TestE2EMefEline:
         data = response.json()
         assert response.status_code == 200, response.text
 
-        expected = [[1, 199], [201, 3798], [3800, 4095]]
+        expected = [[1, 199], [201, 3798], [3800, 4094]]
         assert expected == data[intf_id]["available_tags"]["vlan"]
 
         # Ignoring EVC tag
@@ -446,7 +446,7 @@ class TestE2EMefEline:
         assert response.status_code == 201, response.text
         circuit_id = response.json()["circuit_id"]
 
-        expected = [[1, 9], [16, 3798], [3800, 4095]]
+        expected = [[1, 9], [16, 3798], [3800, 4094]]
         intf_id = '00:00:00:00:00:00:00:01:1'
         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
         response = requests.get(api_url)
@@ -480,7 +480,7 @@ class TestE2EMefEline:
         response = requests.patch(api_url, json=payload)
         assert response.status_code == 200, response.text
 
-        expected = [[1, 11], [22, 3798], [3800, 4095]]
+        expected = [[1, 11], [22, 3798], [3800, 4094]]
         intf_id = '00:00:00:00:00:00:00:01:1'
         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
         response = requests.get(api_url)
@@ -599,7 +599,7 @@ class TestE2EMefEline:
         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
         response = requests.get(topo_url)
         data = response.json()
-        expected = [[1, 3798], [3800, 4095]]
+        expected = [[1, 3798], [3800, 4094]]
         for intf_id in (
             "00:00:00:00:00:00:00:01:1",
             "00:00:00:00:00:00:00:01:3",


### PR DESCRIPTION
Related to PR kytos-ng/kytos#551

### Summary

Updates the tag range in some mef_eline tests to match the new default ranges.

### End-to-End Tests

Here are the results of the modified tests, while using PR kytos-ng/kytos#551.

```
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | Starting ovsdb-server.
kytos-1  | rsyslogd: error during config processing: omfile: chown for file '/var/log/syslog' failed: Operation not permitted [v8.2302.0 try https://www.rsyslog.com/e/2207 ]
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 -m pytest tests/test_e2e_15_mef_eline.py
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
kytos-1  | rootdir: /tests
kytos-1  | plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
kytos-1  | collected 6 items
kytos-1  | 
kytos-1  | tests/test_e2e_15_mef_eline.py ......                                    [100%]
kytos-1  | 
kytos-1  | =============================== warnings summary ===============================
kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-1  | 
kytos-1  | test_e2e_15_mef_eline.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     StrictVersion( '1.10' ) )
kytos-1  | 
kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-1  | ================== 6 passed, 34 warnings in 238.97s (0:03:58) ==================

[Kkytos-1 exited with code 0

```