### PR TITLE
Update delete test by adding a patch

### DIFF
--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -358,8 +358,8 @@ class TestE2EMefEline:
         data = response.json()
         assert data['start_date'] == start.strftime(TIME_FMT)
 
-    def test_delete_circuit_id(self, circuit_id):
-        """ Test circuit removal action. """
+    def test_delete_circuit_id_and_patch(self, circuit_id):
+        """ Test circuit removal action and try to patch it. """
 
         # Delete the circuit
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
@@ -382,3 +382,8 @@ class TestE2EMefEline:
         # Each switch had BASIC_FLOWS flows + 02 for the EVC (ingress + egress)
         # at this point the flow number should be reduced to BASIC_FLOWS
         assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1
+
+        payload = {"enabled": False}
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        response = requests.patch(api_url, json=payload)
+        assert response.status_code == 404, response.text


### PR DESCRIPTION
Closes #349 

### Summary

Just added a patching request to a deleted EVC expecting it to fail

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ -k test_delete_circuit_id_and_patch --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 280 items / 279 deselected / 1 selected

tests/test_e2e_12_mef_eline.py .                                         [100%]
```
