### PR TITLE
[test]: Remove x mark from EVC NNI test.

### DIFF
--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -6,7 +6,7 @@ import requests
 from tests.helpers import NetworkTest
 
 CONTROLLER = '127.0.0.1'
-KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
+KYTOS_API = 'http://%s:8181/api' % CONTROLLER
 
 class TestE2EMefEline:
     net = None
@@ -45,6 +45,38 @@ class TestE2EMefEline:
         # Wait a few seconds to kytos execute LLDP
         time.sleep(10)
 
+    def wait_sdntrace_result(self, trace_id:int, timeout=11):
+        """Wait until sdntrace finishes."""
+        wait_count = 0
+        while wait_count < timeout:
+            try:
+                api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
+                response = requests.get(f"{api_url}/{trace_id}")
+                data = response.json()
+                assert data["result"][-1]["reason"] == "done"
+                break
+            except:
+                time.sleep(1)
+                wait_count += 1
+        else:
+            msg = 'Timeout while waiting from sdntrace result.'
+            raise Exception(msg)
+        return data["result"]
+    
+    def do_sdntrace(self, dpid:str, port:int, vlan:int) -> int:
+        """Do a trace through sdntrace and return the trace_id"""
+        payload = {
+            "trace": {
+                "switch": {"dpid": dpid, "in_port": port},
+                "eth": {"dl_vlan": vlan}
+            }
+        }
+        api_url = KYTOS_API + '/amlight/sdntrace/v1/trace'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        return data["result"]["trace_id"]
+
     def create_evc(
         self,
         uni_a="00:00:00:00:00:00:00:01:1",
@@ -74,14 +106,14 @@ class TestE2EMefEline:
             payload["backup_path"] = backup_path
         if kwargs:
             payload.update(kwargs)
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         data = response.json()
         assert response.status_code == 201, response.text
         return data['circuit_id']
 
     def get_evc_data(self, evc_id:str) -> dict:
-        api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/' + evc_id
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         return response.json()
@@ -90,7 +122,7 @@ class TestE2EMefEline:
         str_avoid_vlan = "false"
         if try_avoid_same_s_vlan:
             str_avoid_vlan = "true"
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{evc_id}/redeploy?try_avoid_same_s_vlan={str_avoid_vlan}"
+        api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/{evc_id}/redeploy?try_avoid_same_s_vlan={str_avoid_vlan}"
         response = requests.patch(api_url)
         assert response.status_code == 202, response.text
         time.sleep(10)
@@ -104,7 +136,7 @@ class TestE2EMefEline:
     def test_005_create_evc_on_nni(self):
         """Test to evaluate how mef_eline will behave when the uni is actually
         an NNI."""
-        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         evc1 = self.create_evc(uni_a='00:00:00:00:00:00:00:16:5',
                                uni_z='00:00:00:00:00:00:00:11:1',
                                vlan_id=100,
@@ -117,6 +149,18 @@ class TestE2EMefEline:
         data = response.json()
         assert data['enabled'] == True
         assert data['active'] == True
+
+        trace_id = self.do_sdntrace('00:00:00:00:00:00:00:16', 5, 100)
+        result = self.wait_sdntrace_result(trace_id)
+
+        assert len(result) == 7
+        assert result[0]["dpid"] == "00:00:00:00:00:00:00:16"
+        assert result[1]["dpid"] == "00:00:00:00:00:00:00:15"
+        assert result[2]["dpid"] == "00:00:00:00:00:00:00:12"
+        assert result[3]["dpid"] == "00:00:00:00:00:00:00:17"
+        assert result[4]["dpid"] == "00:00:00:00:00:00:00:11"
+        assert result[5]["dpid"] == "00:00:00:00:00:00:00:12"
+        assert result[6]["type"] == "last"
 
     def test_010_redeploy_avoid_vlan(self):
         """Test if dynamic EVC takes different VLAN when redeploying."""
@@ -278,7 +322,7 @@ class TestE2EMefEline:
 
         # Deployment to primary_path
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6654")
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{evc}/redeploy"
+        api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/{evc}/redeploy"
         response = requests.patch(api_url)
         assert response.status_code == 409, response.text
         evc_content = self.get_evc_data(evc)
@@ -299,7 +343,7 @@ class TestE2EMefEline:
 
         # Deployment to backup_path
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6654")
-        api_url = f"{KYTOS_API}/mef_eline/v2/evc/{evc}/redeploy"
+        api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/{evc}/redeploy"
         response = requests.patch(api_url)
         assert response.status_code == 409, response.text
         evc_content = self.get_evc_data(evc)


### PR DESCRIPTION
Closes #347 

### Summary

Removed x mark in creation of an EVC with NNIs as UNIs

### Local Tests
N/A

### End-to-End Tests
With branch `feature/evc_paths` from [PR](https://github.com/kytos-ng/mef_eline/pull/644)
```
+ python3 -m pytest tests/ -k test_005_create_evc_on_nni --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 280 items / 279 deselected / 1 selected

tests/test_e2e_14_mef_eline.py .                                         [100%]
```

All other other tests in the file
```
+ python3 -m pytest tests/test_e2e_14_mef_eline.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 5 items

tests/test_e2e_14_mef_eline.py .....                                     [100%]
```
