### PR TITLE
Update test to redeploy active EVC

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1274,9 +1274,23 @@ class TestE2EMefEline:
         for _path in data['current_path']:
             paths.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
                           "endpoint_b": {"id": _path['endpoint_b']['id']}})
+            
+        assert paths == current_path
 
         # Command to up/down links to test if back-up path is taken
+        # EVC should not redeploy
         self.net.net.configLinkStatus('s1', 's2', 'up')
+
+        # Wait just a few seconds to give time to the controller receive and process the linkUp event
+        time.sleep(10)
+
+        response = requests.get(api_url + evc1)
+        data = response.json()
+
+        paths = []
+        for _path in data['current_path']:
+            paths.append({"endpoint_a": {"id": _path['endpoint_a']['id']},
+                          "endpoint_b": {"id": _path['endpoint_b']['id']}})
 
         assert paths == current_path
 


### PR DESCRIPTION
Closes #348 

### Summary

Redeploy active EVC and check if its `current_path` did not changed.

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ -k test_145_current_path_value_given_dynamic_backup_path_and_empty_primary_conditions --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 280 items / 279 deselected / 1 selected

tests/test_e2e_10_mef_eline.py .                                         [100%]
```
