### PR TITLE
Update test_e2e_14_mef_eline.py

### DIFF
--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -363,6 +363,7 @@ class TestE2EMefEline:
         for current, backup in zip(current_path, backup_path):
             assert current["endpoint_a"]["id"] == backup["endpoint_a"]["id"]
             assert current["endpoint_b"]["id"] == backup["endpoint_b"]["id"]
+        self.net.reconnect_switches()
 
     def test_030_EVC_path_disjointness(self):
         """Testing disjointness by expecting a specific failover_path."""
@@ -396,3 +397,4 @@ class TestE2EMefEline:
         ]
         assert len(failover_path) == len(expected_failover_path)
         assert failover_path == expected_failover_path
+        self.net.net.configLinkStatus('Ampath1', 'SoL2', 'up')


### PR DESCRIPTION
Closes #356 

### Summary

Switches were not able to be connected. Problem was in `test_025_uni_link_up_static_path`

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_14_mef_eline.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 6 items

tests/test_e2e_14_mef_eline.py ......                                    [100%]
```

