### PR TITLE
Added test for mismatched links

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -278,6 +278,19 @@ class NetworkTest:
         """Drop database."""
         self.db_client.drop_database(self.db_name)
 
+    def stop_kytosd(self):
+        """Stop kytosd process."""
+        try:
+            os.system('pkill kytosd')
+            time.sleep(5)
+            pid_path = os.path.join(BASE_ENV, 'var/run/kytos/kytosd.pid')
+            if os.path.exists(pid_path):
+                raise Exception("kytos pid still exists.")
+        except Exception as e:
+            print(f"FAIL to stop kytos after 5 seconds -- {e}. Force stop!")
+            os.system('pkill -9 kytosd')
+            os.system(f"rm -f {pid_path}")
+
     def start_controller(self, clean_config=False, enable_all=False,
                          del_flows=False, port=None, database='mongodb',
                          extra_args=os.environ.get("KYTOSD_EXTRA_ARGS", "")):


### PR DESCRIPTION
Closes #360

### Summary

This tests needs two branches:
of_core -> bug/replaced_interface from [PR](https://github.com/kytos-ng/of_core/pull/149)
topology -> bug/link_order from [PR](https://github.com/kytos-ng/topology/pull/255)

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ -k test_130_mismatched_links --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 285 items / 284 deselected / 1 selected

tests/test_e2e_05_topology.py .                                          [100%]
```
All the tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 285 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 23%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 43%]
tests/test_e2e_14_mef_eline.py ......                                    [ 45%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 48%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .........R..................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 71%]
tests/test_e2e_31_of_lldp.py ...                                         [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```