### PR TITLE
tests: augmented test_120_patch_queue_id to cover set_queue order

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -994,8 +994,9 @@ class TestE2EMefEline:
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
 
-        assert 'set_queue:3' in flows_s1
-        assert 'set_queue:3' in flows_s2
+        # also asserts set_queue comes before output
+        assert 'set_queue:3,output' in flows_s1
+        assert 'set_queue:3,output' in flows_s2
 
     def test_125_patch_dynamic_backup_path(self):
         """Test patching an EVC to be non dynamic with primary_path."""


### PR DESCRIPTION
Closes #362 

### Summary

- Related to https://github.com/kytos-ng/mef_eline/pull/673

### Local Tests / End-to-End Tests

- Ran this augmented test case with this branch:

```
+ python3 -m pytest tests/ -k test_120_patch_queue_id --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 284 items / 283 deselected / 1 selected
tests/test_e2e_10_mef_eline.py .                                         [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
  /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '-k', 'test_120_patch_queue_id', '--reruns', '2', '-r', 'fEr']
    warnings.warn(f"Unknown arguments: {unknown}")
tests/test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 283 deselected, 35 warnings in 84.81s (0:01:24) ===========
```

- Also ran e2e mef_eline test cases with this branch:

```
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/ -k mef_eline --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 285 items / 168 deselected / 117 selected
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 35%]
.                                                                        [ 35%]
tests/test_e2e_11_mef_eline.py ......                                    [ 41%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 47%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 82%]
.                                                                        [ 83%]
tests/test_e2e_14_mef_eline.py ......                                    [ 88%]
tests/test_e2e_15_mef_eline.py ......                                    [ 94%]
tests/test_e2e_16_mef_eline.py ..                                        [ 95%]
tests/test_e2e_17_mef_eline.py ....                                      [ 99%]
tests/test_e2e_60_of_multi_table.py .                                    [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254

```

