### PR TITLE
feat: cover GET /api/amlight/kytos_stats/v1/port/stats endpoint

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -333,7 +333,7 @@ class TestE2EKytosStats:
                 {
                     "match": {"in_port": 1},
                     "actions": [{"action_type": "output", "port": 2}],
-                }
+                },
                 {
                     "match": {"in_port": 2},
                     "actions": [{"action_type": "output", "port": 1}],

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -324,3 +324,57 @@ class TestE2EKytosStats:
 
         assert data[sw]['1']['active_count'] < data_1[sw]['1']['active_count']
 
+    def test_040_port_stats_tx_rx_packets(self):
+        """Test port stats tx and rx stats."""
+        sw = "00:00:00:00:00:00:00:01"
+        # bidir flow between port 1 and 2 for data plane test
+        payload = {
+            "flows": [
+                {
+                    "match": {"in_port": 1},
+                    "actions": [{"action_type": "output", "port": 2}],
+                }
+                {
+                    "match": {"in_port": 2},
+                    "actions": [{"action_type": "output", "port": 1}],
+                }
+            ]
+        }
+
+        api_url_flow_manager = KYTOS_API + f"/kytos/flow_manager/v2/flows/{sw}"
+        response = requests.post(
+            api_url_flow_manager,
+            data=json.dumps(payload),
+            headers={"Content-type": "application/json"},
+        )
+        assert response.status_code == 202, response.text
+        data_flow = response.json()
+        assert "FlowMod Messages Sent" in data_flow["response"]
+
+        # wait the flow to be installed
+        time.sleep(10)
+
+        # set hosts IP and perform a ping
+        h11, h12 = self.net.net.get('h11', 'h12')
+        h11.cmd('ip link add link %s name vlan101 type vlan id 101' % (h11.intfNames()[0]))
+        h11.cmd('ip link set up vlan101')
+        h11.cmd('ip addr add 10.1.1.11/24 dev vlan101')
+        h12.cmd('ip link add link %s name vlan101 type vlan id 101' % (h12.intfNames()[0]))
+        h12.cmd('ip link set up vlan101')
+        h12.cmd('ip addr add 10.1.1.12/24 dev vlan101')
+
+        result = h11.cmd('ping -c1 10.1.1.12')
+        assert ', 0% packet loss,' in result
+
+        # give enough time for stats gathering
+        time.sleep(20)
+        port = "1"
+        api_url = f"{KYTOS_STATS}/port/stats?dpid={sw}&port={port}"
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+
+        assert sw in data, data
+        assert port in data[sw], data[sw]
+        assert data[sw][port]["tx_packets"]
+        assert data[sw][port]["rx_packets"]


### PR DESCRIPTION
Closes #366 

### Summary

- Added `test_040_port_stats_tx_rx_packets` test case; initial e2e test coverage for https://github.com/kytos-ng/kytos_stats/issues/24


### Local Tests

Ran this test case with this branch and the `kytos_stats` related branch that @italovalcy is working on

```
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/ -k test_040_port_stats_tx_rx_packets --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 286 items / 285 deselected / 1 selected
tests/test_e2e_70_kytos_stats.py .                                       [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
  /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '-k', 'test_040_port_stats_tx_rx_packets', '--reruns', '2', '-r', 'fEr']
    warnings.warn(f"Unknown arguments: {unknown}")
tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 285 deselected, 35 warnings in 110.14s (0:01:50) ==========
```

### End-to-End Tests

```
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/ -k test_040_port_stats_tx_rx_packets --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 286 items / 285 deselected / 1 selected
tests/test_e2e_70_kytos_stats.py .                                       [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
  /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '-k', 'test_040_port_stats_tx_rx_packets', '--reruns', '2', '-r', 'fEr']
    warnings.warn(f"Unknown arguments: {unknown}")
tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 285 deselected, 35 warnings in 110.14s (0:01:50) ==========
```
