### PR TITLE
Made sure that qinq is not present in flows

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -246,7 +246,9 @@ class TestE2EMefEline:
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'in_port="s1-eth1",dl_vlan=102' in flows_s1
+        assert 'push_vlan:0x88a8' not in flows_s1
         assert 'in_port="s2-eth1",dl_vlan=103' in flows_s2
+        assert 'push_vlan:0x88a8' not in flows_s2
 
         # Make the final and most important test: connectivity
         # 1. create the vlans and setup the ip addresses
@@ -1636,8 +1638,6 @@ class TestE2EMefEline:
         expected = [
             {"match": {"in_port": 1, "dl_vlan": 100},
             "actions": [
-                {"action_type": "pop_vlan"},
-                {"action_type": "push_vlan", "tag_type": "s"},
                 {"action_type": "set_vlan", "vlan_id": 1},
                 {"action_type": "output", "port": 3}
             ],
@@ -1645,8 +1645,6 @@ class TestE2EMefEline:
             {"match": {"in_port": 1, "dl_vlan": 0},
             "actions": [
                 {"action_type": "push_vlan", "tag_type": "c"},
-                {"action_type": "set_vlan", "vlan_id": 100},
-                {"action_type": "push_vlan", "tag_type": "s"},
                 {"action_type": "set_vlan", "vlan_id": 1},
                 {"action_type": "output", "port": 2}
             ],


### PR DESCRIPTION
Closes #374 

### Summary

Checking for qinq encapsulation in existent tests.

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/ -k 'test_175_create_100_untagged_evc or test_025_create_evc_different_tags_each_side' --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: timeout-2.2.0, rerunfailures-13.0, anyio-4.3.0
collected 287 items / 285 deselected / 2 selected

tests/test_e2e_10_mef_eline.py ..                                        [100%]
```

All the tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.6.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 287 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 42%]
.                                                                        [ 42%]
tests/test_e2e_14_mef_eline.py ......                                    [ 44%]
tests/test_e2e_15_mef_eline.py ......                                    [ 47%]
tests/test_e2e_16_mef_eline.py ..                                        [ 47%]
tests/test_e2e_17_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 70%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 79%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 82%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ............................            [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py ........                                [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
```