### PR TITLE
Fix/flaky tests

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -35,9 +35,9 @@ test -z "$RERUNS" && RERUNS=2
 python3 scripts/wait_for_mongo.py 2>/dev/null
 python3 scripts/setup_kafka.py 2>/dev/null
 
-#python3 -m pytest $TESTS --reruns $RERUNS -r fEr
+python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 
 #tail -f
 
 # only run specific test
-python3 -m pytest tests/test_e2e_90_kafka_events.py --reruns 10 -r fEr
+# python3 -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup

--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -138,7 +138,7 @@ class TestE2EKafkaEvents:
                 break
 
             try:
-                # Wait up to 1 second for messages
+                # Wait up to 2 seconds for messages
                 results = await consumer.getmany(timeout_ms=2000)
 
                 # Ensure values exist


### PR DESCRIPTION
Closes #384 

### Summary

Enhanced the test logic to pull multiple times, rather than wait long periods. This reduces flakiness by allowing for more data to be sent from Kafka **and** allows more time for the data to propagate.

### Local Tests

### End-to-End Tests

Ran multiple tests via the GitLab manual runner, showing `<= 1` reruns max.
