### PR TITLE
Test patching inter and intra switch EVCs

### DIFF
--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -146,6 +146,12 @@ class TestE2EMefEline:
             100
         )
 
+        self.assert_tag_used_by_interface(
+            "00:00:00:00:00:00:00:01:2",
+            "vlan",
+            100
+        )
+
         api_url = KYTOS_API + f"/kytos/mef_eline/v2/evc/{evc_id}"
         response = requests.get(api_url)
 
@@ -207,6 +213,12 @@ class TestE2EMefEline:
         # Check old uni_z
         self.assert_tag_not_used_by_interface(
             "00:00:00:00:00:00:00:02:1",
+            "vlan",
+            100
+        )
+
+        self.assert_tag_used_by_interface(
+            "00:00:00:00:00:00:00:01:2",
             "vlan",
             100
         )


### PR DESCRIPTION
Part of kytos-ng/mef_eline#618

### Summary

Tests patching EVCs, where the UNIs are changed, to ensure that resources are properly reallocated.

### Local Tests

Currently the inter switch test passes, but the intra switch test fails. If you look deeper into the intra switch case, you can see that while the `uni_z` has not changed, the tags were deallocated for it, and tags where allocated for the new `uni_z`.