### PR TITLE
Test interface down and interface disable effect on EVCs

### DIFF
--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -1,11 +1,14 @@
 import requests
 import time
+from datetime import datetime, timedelta, UTC, timezone
 
 
 from .helpers import NetworkTest
 
 CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api' % CONTROLLER
+
+TIME_FMT = "%Y-%m-%dT%H:%M:%S+0000"
 
 class TestE2EMefEline:
     net = None
@@ -259,7 +262,7 @@ class TestE2EMefEline:
         evc_id = data["circuit_id"]
 
         # Disable current uni_a
-        api_url = KYTOS_API + "/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:01:2/disable"
+        api_url = KYTOS_API + "/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:01:1/disable"
         response = requests.post(api_url)
         assert response.status_code == 200, response.text
 
@@ -275,7 +278,7 @@ class TestE2EMefEline:
         # Check that EVC has been deactivated.
         data = response.json()
         assert not data["active"]
-        assert not data["current_path"]
+        assert data['current_path']
 
     def test_040_interface_down(self):
         payload = {
@@ -305,7 +308,7 @@ class TestE2EMefEline:
         evc_id = data["circuit_id"]
 
         # Disable current uni_a
-        self.net.net.configLinkStatus("s1", "h12", "down")
+        self.net.net.configLinkStatus("s1", "h11", "down")
 
         # Wait for events to be sent out
         time.sleep(5)
@@ -319,4 +322,57 @@ class TestE2EMefEline:
         # Check that EVC has been deactivated.
         data = response.json()
         assert not data["active"]
-        assert not data["current_path"]
+        assert data['current_path']
+
+    def test_050_interface_maintenance(self):
+        payload = {
+            "name": "Test EVC",
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                },
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                },
+            },
+            "enabled": True,
+            "dynamic_backup_path": True,
+        }
+        api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/"
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+        data = response.json()
+
+        evc_id = data["circuit_id"]
+
+        mw_start_delay = 10
+        start = datetime.now(timezone.utc) + timedelta(seconds=mw_start_delay)
+        payload = {
+            "description": "mw for test 050",
+            "start": start.strftime(TIME_FMT),
+            "end": None,
+            "interfaces": ["00:00:00:00:00:00:00:01:1"],
+            "force": True,
+        }
+        api_URL = f'{KYTOS_API}/kytos/maintenance/v1/'
+        response = requests.post(api_URL, json=payload)
+        assert response.status_code == 201, response.text
+
+        time.sleep(5)
+
+        # Check that evc is deactivated.
+        api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/{evc_id}"
+        response = requests.get(api_url)
+        
+        assert response.status_code == 200, response.text
+
+        # Check that EVC has been deactivated.
+        data = response.json()
+        assert not data["active"]
+        assert data['current_path']

--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -351,7 +351,7 @@ class TestE2EMefEline:
 
         evc_id = data["circuit_id"]
 
-        mw_start_delay = 10
+        mw_start_delay = 2
         start = datetime.now(timezone.utc) + timedelta(seconds=mw_start_delay)
         payload = {
             "description": "mw for test 050",
@@ -364,7 +364,7 @@ class TestE2EMefEline:
         response = requests.post(api_URL, json=payload)
         assert response.status_code == 201, response.text
 
-        time.sleep(5)
+        time.sleep(7)
 
         # Check that evc is deactivated.
         api_url = f"{KYTOS_API}/kytos/mef_eline/v2/evc/{evc_id}"

--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -69,6 +69,7 @@ class TestE2EMefEline:
                 break
         else:
             assert True, available_tags
+            return
         assert False, available_tags
 
     def assert_tag_not_used_by_interface(self, interface_id, tag_type, value):


### PR DESCRIPTION
Part of kytos-ng/mef_eline#698

### Summary

Adds tests for checking that evcs are deactivated if their UNIs are down or disabled. Also adds in a missing return for the assert statements added in my last PR (whoops).

### Local Tests

Both new tests fail. as the new expected behaviour hasn't been implemented yet.

```
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | rsyslogd: error during config processing: omfile: chown for file '/var/log/syslog' failed: Operation not permitted [v8.2302.0 try https://www.rsyslog.com/e/2207 ]
kytos-1  | Starting ovsdb-server.
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-1  | + sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' /etc/kytos/logging.ini
kytos-1  | + echo -e '\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka'
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 scripts/setup_kafka.py
kytos-1  | Starting setup_kafka.py...
kytos-1  | Attempting to create an admin client at ['broker1:19092', 'broker2:19092', 'broker3:19092']...
kytos-1  | Admin client was successful! Attempting to validate cluster...
kytos-1  | Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'broker1', 'port': 19092, 'rack': None}, {'node_id': 2, 'host': 'broker2', 'port': 19092, 'rack': None}, {'node_id': 3, 'host': 'broker3', 'port': 19092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 2}
kytos-1  | Cluster was successfully validated! Attempting to create topic 'event_logs'...
kytos-1  | Topic 'event_logs' was created! Attempting to close the admin client...
kytos-1  | Kafka admin client closed.
kytos-1  | + python3 -m pytest tests/test_e2e_18_mef_eline.py
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
kytos-1  | rootdir: /
kytos-1  | configfile: pytest.ini
kytos-1  | plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
kytos-1  | asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
kytos-1  | collected 4 items
kytos-1  | 
kytos-1  | tests/test_e2e_18_mef_eline.py ..FF                                      [100%]
kytos-1  | 
kytos-1  | =================================== FAILURES ===================================
kytos-1  | _________________ TestE2EMefEline.test_030_interface_disabled __________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_18_mef_eline.TestE2EMefEline object at 0x78eb0fee8150>
kytos-1  | 
kytos-1  |     def test_030_interface_disabled(self):
kytos-1  |         payload = {
kytos-1  |             "name": "Test EVC",
kytos-1  |             "uni_a": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |                 "tag": {
kytos-1  |                     "tag_type": "vlan",
kytos-1  |                     "value": 100,
kytos-1  |                 },
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |                 "tag": {
kytos-1  |                     "tag_type": "vlan",
kytos-1  |                     "value": 100,
kytos-1  |                 },
kytos-1  |             },
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + "/kytos/mef_eline/v2/evc/"
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         data = response.json()
kytos-1  |     
kytos-1  |         evc_id = data["circuit_id"]
kytos-1  |     
kytos-1  |         # Disable current uni_a
kytos-1  |         api_url = KYTOS_API + "/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:01:2/disable"
kytos-1  |         response = requests.post(api_url)
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Wait for events to be sent out
kytos-1  |         time.sleep(5)
kytos-1  |     
kytos-1  |         # Check that evc is deactivated.
kytos-1  |         api_url = KYTOS_API + f"/kytos/mef_eline/v2/evc/{evc_id}"
kytos-1  |         response = requests.get(api_url)
kytos-1  |     
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Check that EVC has been deactivated.
kytos-1  |         data = response.json()
kytos-1  | >       assert not data["active"]
kytos-1  | E       assert not True
kytos-1  | 
kytos-1  | tests/test_e2e_18_mef_eline.py:277: AssertionError
kytos-1  | ___________________ TestE2EMefEline.test_040_interface_down ____________________
kytos-1  | 
kytos-1  | self = <tests.test_e2e_18_mef_eline.TestE2EMefEline object at 0x78eb0fee8890>
kytos-1  | 
kytos-1  |     def test_040_interface_down(self):
kytos-1  |         payload = {
kytos-1  |             "name": "Test EVC",
kytos-1  |             "uni_a": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:01:1",
kytos-1  |                 "tag": {
kytos-1  |                     "tag_type": "vlan",
kytos-1  |                     "value": 100,
kytos-1  |                 },
kytos-1  |             },
kytos-1  |             "uni_z": {
kytos-1  |                 "interface_id": "00:00:00:00:00:00:00:02:1",
kytos-1  |                 "tag": {
kytos-1  |                     "tag_type": "vlan",
kytos-1  |                     "value": 100,
kytos-1  |                 },
kytos-1  |             },
kytos-1  |             "enabled": True,
kytos-1  |             "dynamic_backup_path": True,
kytos-1  |         }
kytos-1  |         api_url = KYTOS_API + "/kytos/mef_eline/v2/evc/"
kytos-1  |         response = requests.post(api_url, json=payload)
kytos-1  |         assert response.status_code == 201, response.text
kytos-1  |         data = response.json()
kytos-1  |     
kytos-1  |         evc_id = data["circuit_id"]
kytos-1  |     
kytos-1  |         # Disable current uni_a
kytos-1  |         self.net.net.configLinkStatus("s1", "h12", "down")
kytos-1  |     
kytos-1  |         # Wait for events to be sent out
kytos-1  |         time.sleep(5)
kytos-1  |     
kytos-1  |         # Check that evc is deactivated.
kytos-1  |         api_url = KYTOS_API + f"/kytos/mef_eline/v2/evc/{evc_id}"
kytos-1  |         response = requests.get(api_url)
kytos-1  |     
kytos-1  |         assert response.status_code == 200, response.text
kytos-1  |     
kytos-1  |         # Check that EVC has been deactivated.
kytos-1  |         data = response.json()
kytos-1  | >       assert not data["active"]
kytos-1  | E       assert not True
kytos-1  | 
kytos-1  | tests/test_e2e_18_mef_eline.py:321: AssertionError
kytos-1  | =============================== warnings summary ===============================
kytos-1  | tests/test_e2e_18_mef_eline.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     return ( StrictVersion( cls.OVSVersion ) <
kytos-1  | 
kytos-1  | tests/test_e2e_18_mef_eline.py: 17 warnings
kytos-1  |   /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
kytos-1  |     StrictVersion( '1.10' ) )
kytos-1  | 
kytos-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
kytos-1  | ------------------------------- start/stop times -------------------------------
kytos-1  | tests/test_e2e_18_mef_eline.py::TestE2EMefEline::test_030_interface_disabled: 2025-09-25,15:35:07.514868 - 2025-09-25,15:35:12.760197
kytos-1  | tests/test_e2e_18_mef_eline.py::TestE2EMefEline::test_040_interface_down: 2025-09-25,15:35:37.683027 - 2025-09-25,15:35:42.914026
kytos-1  | =========================== short test summary info ============================
kytos-1  | FAILED tests/test_e2e_18_mef_eline.py::TestE2EMefEline::test_030_interface_disabled
kytos-1  | FAILED tests/test_e2e_18_mef_eline.py::TestE2EMefEline::test_040_interface_down
kytos-1  | ============= 2 failed, 2 passed, 34 warnings in 151.26s (0:02:31) =============

[Kkytos-1 exited with code 1

```

