### PR TITLE
Giving more time to kafka setup

### DIFF
--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -71,7 +71,7 @@ class TestE2EKafkaEvents:
         await self.admin.delete_topics([KAFKA_TOPIC], TIMEOUT)
 
         # Let the topic deletion propagate
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
 
     async def topic_exists(self):
         """
@@ -93,7 +93,7 @@ class TestE2EKafkaEvents:
         )
 
         # Let the topic creation propagate
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
 
     async def test_01_napp_sends_data_correctly(self):
         """


### PR DESCRIPTION
Closes #394

### Summary

Added `await` to wait for topic listing
Increased sleep time from 2 to 5 seconds.

### Local Tests
N/A

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_90_kafka_events.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: timeout-2.2.0, rerunfailures-13.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

tests/test_e2e_90_kafka_events.py .                                      [100%]

=============================== warnings summary ===============================
tests/test_e2e_90_kafka_events.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_90_kafka_events.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
======================= 1 passed, 34 warnings in 55.80s ========================

```