### PR TITLE
test: added test_005_link_down_current_path_failover_path

### DIFF
--- a/tests/test_e2e_17_mef_eline.py
+++ b/tests/test_e2e_17_mef_eline.py
@@ -531,7 +531,7 @@ class TestE2EMefEline:
 
         cookie = int(f"0xaa{evc_id}", 16)
 
-        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}'
+        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}&state=installed'
         response = requests.get(stored_flows)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -555,7 +555,7 @@ class TestE2EMefEline:
 
         # Check that all related flows have been removed
 
-        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}'
+        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}&state=installed'
         response = requests.get(stored_flows)
         assert response.status_code == 200, response.text
         data = response.json()


### PR DESCRIPTION
Closes https://github.com/kytos-ng/mef_eline/issues/702

### Summary

- Related to https://github.com/kytos-ng/mef_eline/pull/703
- Added `test_005_link_down_current_path_failover_path` to cover a case when a shared link between current_path and failover_path goes down and the expected flows

### Local Tests

Running on GitLab:

```
+ python3 -m pytest tests/ -k test_005_link_down_current_path_failover_path --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 298 items / 297 deselected / 1 selected
tests/test_e2e_17_mef_eline.py .                                         [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254
  /usr/local/lib/python3.11/dist-packages/kytos/core/config.py:254: UserWarning: Unknown arguments: ['tests/', '-k', 'test_005_link_down_current_path_failover_path', '--reruns', '2', '-r', 'fEr']
    warnings.warn(f"Unknown arguments: {unknown}")
tests/test_e2e_17_mef_eline.py: 37 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_17_mef_eline.py: 37 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 297 deselected, 75 warnings in 109.54s (0:01:49) ==========
```

### End-to-End Tests

They're passing, there were reruns but unrelated to this change:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 298 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ......                                    [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 40%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ........R.................R...         [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py R.                                     [100%]
=============================== warnings summary ===============================
=========================== rerun test summary info ============================
RERUN tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_026_delete_flows_cookie_mask_range
RERUN tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_100_install_delete_flows_in_switch_list
RERUN tests/test_e2e_90_kafka_events.py::TestE2EKafkaEvents::test_01_napp_sends_data_correctly
= 276 passed, 8 skipped, 7 xfailed, 7 xpassed, 1357 warnings, 3 rerun in 15158.72s (4:12:38) =
```
