### PR TITLE
Updated pytest version in requirements-local.txt

### DIFF
--- a/requirements/requirements-local.txt
+++ b/requirements/requirements-local.txt
@@ -1,5 +1,5 @@
 pytest-timeout==2.2.0
-pytest==8.1.1
+pytest==8.2.0
 pytest-asyncio==1.1.0
 pytest-rerunfailures==13.0
 mock==5.1.0


### PR DESCRIPTION
Closes #404 

### Summary

Updated pytest to version 8.2.0 within requirements-local.txt because of dependency version conflicts.

### Local Tests

I was able to install all of the dependencies without issues.
