### PR TITLE
Feat: adding helper function to wait for Kytos links

### DIFF
--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -940,8 +940,8 @@ class TestE2EMefEline:
         payload2 = {
             "current_path": [
                 {
-                    {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"}},
-                    {"endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"}},
+                    "endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
+                    "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"},
                 },
             ]
         }


### PR DESCRIPTION
Related to #200

### Summary

This improvement is related to the performance/delay when executing the tests with Noviflow backend. We added this new helper that waits for Kytos links to be properly discovered/loaded before proceeding with the tests.

### End-to-End Tests

Here are the results of running the end-to-end tests with OpenVSwitch backend and all the recent PRs stacked (#409, #410, #411, #412, #413, #414):

```

> kubectl --kubeconfig $KUBECONFIG apply -f kytos-mongo-kafka2.yaml
deployment.apps/kytos-regression-tests2 created

> kubectl --kubeconfig $KUBECONFIG rollout status deployment/kytos-regression-tests2 --timeout=120s
Waiting for deployment "kytos-regression-tests2" rollout to finish: 0 of 1 updated replicas are available...
deployment "kytos-regression-tests2" successfully rolled out

> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container mongo1 -- mongosh --eval 'db.getSiblingDB("kytosdb").createUser({user: "kytosuser", pwd: "kytospass", roles: [ { role: "dbAdmin", db: "kytosdb" } ]})'
{ ok: 1 }

> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container kytos -- git clone --branch feat/adding-noviswitch-backend https://github.com/kytos-ng/kytos-end-to-end-tests
Cloning into 'kytos-end-to-end-tests'...
...

> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container kytos -- bash -c "service rsyslog start; service openvswitch-switch start; apt-get update; apt-get install -y python3-paramiko openssh-client"
Starting enhanced syslogd: rsyslogd.
/etc/openvswitch/conf.db does not exist ... (warning).
Creating empty database /etc/openvswitch/conf.db.
nice: cannot set niceness: Permission denied
Starting ovsdb-server.
...

# this was done temporarily because of the issues we are having with Kafka-events
> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container kytos -- bash -c 'sed -ri "s/LINGER_MS = .*/LINGER_MS = 0/g; s/KAFKA_TIMELIMIT = .*/KAFKA_TIMELIMIT = 10/g" $NAPPS_PATH/var/lib/kytos/napps/kytos/kafka_events/settings.py'

> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container kytos -- tmux new-session -d -s kytos-tests -e RERUNS=4 bash -c 'cd kytos-end-to-end-tests/; ./kytos-init.sh 2>&1 | tee /results-kytos-e2e.txt'

# wait a few hours

> kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests2 --container kytos -- cat /results-kytos-e2e.txt
...
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 300 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py .........                               [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [100%]
------------------------------- start/stop times -------------------------------
= 278 passed, 8 skipped, 7 xfailed, 7 xpassed, 1359 warnings in 13961.35s (3:52:41) =
```