### PR TITLE
Updated test to be more resilient

### DIFF
--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -41,7 +41,7 @@ class TestE2EKafkaEvents:
     def teardown_class(cls):
         cls.net.stop()
 
-    async def check_for_assignments(self, consumer, max_tries, sleep_interval):
+    async def check_for_assignments(self, consumer, max_tries=4, sleep_interval=0.5):
         """Check the consumer for assignments."""
         tries = 1
         while not consumer.assignment():
@@ -66,7 +66,7 @@ class TestE2EKafkaEvents:
         await consumer.start()
 
         # Make sure consumer has assignments
-        await self.check_for_assignments(consumer, 4, 0.5)
+        await self.check_for_assignments(consumer)
 
         # Create an EVC-creation event to send to Kafka
 


### PR DESCRIPTION
Related to #394

### Summary

Updated so consumer gets earlier messages and check if it has any assignments

### Local Tests
Tried manually deploying in gitlab and it did not failed a single time

### End-to-End Tests
```
+ python3 -m pytest tests/test_e2e_90_kafka_events.py tests/test_e2e_01_kytos_startup.py --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 3 items

tests/test_e2e_90_kafka_events.py .                                      [ 33%]
tests/test_e2e_01_kytos_startup.py ..                                    [100%]
```
