### PR TITLE
Seeking to end

### DIFF
--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -41,6 +41,15 @@ class TestE2EKafkaEvents:
     def teardown_class(cls):
         cls.net.stop()
 
+    async def check_for_assignments(self, consumer, max_tries=4, sleep_interval=0.5):
+        """Check the consumer for assignments."""
+        tries = 1
+        while not consumer.assignment():
+            await asyncio.sleep(sleep_interval)
+            if tries > max_tries:
+                assert False, "Consumer does not get assignments."
+            tries += 1
+
     async def test_01_napp_sends_data_correctly(self):
         """
         Test that kafka_events correctly runs the 'setup' method. This would require

--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -60,13 +60,13 @@ class TestE2EKafkaEvents:
         consumer = AIOKafkaConsumer(
             (KAFKA_TOPIC),
             bootstrap_servers=KAFKA_ADDRESSES,
-            auto_offset_reset='earliest', # Consume earlier messages
         )
 
         await consumer.start()
 
-        # Make sure consumer has assignments
+        # Make sure consumer has assignments and waits for them
         await self.check_for_assignments(consumer)
+        await consumer.seek_to_end()
 
         # Create an EVC-creation event to send to Kafka
 
@@ -103,7 +103,7 @@ class TestE2EKafkaEvents:
 
         found = False
 
-        for _ in range(4):
+        for _ in range(5):
 
             if found:
                 break


### PR DESCRIPTION
Related #394 

### Summary

After doing more tests, the `earliest` option was capturing lots of logs from previous tests and slowing the the capturing of the evc created log for the Kafka test. So it has been removed.
Instead `seek_to_end()` is now executing to make sure assignments are ready. By [default](https://aiokafka.readthedocs.io/en/stable/_modules/aiokafka/consumer/consumer.html#AIOKafkaConsumer.seek_to_end) it is going to wait 40 seconds.

### Local Tests

### End-to-End Tests
I run them but decided to run them again without  copying the results. Gonna post the result once all the 301 tests results are ready.
