### PR TITLE
Added test when adding an interface while kytos is running.

### DIFF
--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -280,18 +280,33 @@ class TestE2ETopology:
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        s1_intfs_before = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_before = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
 
+        s1_db = self.net.db.switches.find({"id":"00:00:00:00:00:00:00:01"})
+        s1_docu = list(s1_db)
+        assert len(s1_docu) == 1, "Switch 1 not found"
+        db_intfs_before = len(s1_docu[0]["interfaces"])
+        assert memo_intfs_before == db_intfs_before
+
+        # Add interface to s1 and s3
         S1, S3 = self.net.net.get('s1', 's3')
         self.net.net.addLink(S1, S3, port1=20, port2=20)
         S1.attach('s1-eth20')
         S3.attach('s3-eth20')
         time.sleep(2)
 
-        # Look new interface in the database
+        # Look for new interface in the database
+        s1_db = self.net.db.switches.find({"id":"00:00:00:00:00:00:00:01"})
+        s1_docu = list(s1_db)
+        assert len(s1_docu) == 1, "Switch 1 not found"
+        db_intfs_after = len(s1_docu[0]["interfaces"])
+        assert db_intfs_after == db_intfs_before + 1
+
+        # Look for new interface in the memory
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        s1_intfs_after = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_after = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
 
-        assert s1_intfs_before + 1 == s1_intfs_after
+        assert memo_intfs_after == memo_intfs_before + 1
+        assert db_intfs_after == memo_intfs_after

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -264,9 +264,11 @@ class TestE2ETopology:
         assert not intf_id in data["interfaces"]
 
         # Delete link from mininet
+        n_links_before = len(self.net.net.links)
         topo_links = self.net.net.linksBetween(S2, S6)
-        assert len(topo_links) == 1, f"Multi topo s2 and s6 only had 1 link now: {topo_links}"
+        assert len(topo_links) == 1, f"In Multi topo, s2 and s6 only had 1 link now: {topo_links}"
         self.net.net.delLink(topo_links[0])
+        assert n_links_before == len(self.net.net.links) + 1, "Link from s2 and s6 was not deleted."
 
     def test_030_add_interface(self):
         """Test adding an interface while kytos is running

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -212,7 +212,7 @@ class TestE2ETopology:
         assert response.status_code == 409, response.text
 
         # Interface has a link
-        S2 = self.net.net.get('s2')
+        S2, S6 = self.net.net.get('s2', 's6')
         S2.detach('s2-eth4')
 
         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
@@ -262,3 +262,34 @@ class TestE2ETopology:
         assert response.status_code == 200, response.text
         data = response.json()
         assert not intf_id in data["interfaces"]
+
+        # Delete link from mininet
+        topo_links = self.net.net.linksBetween(S2, S6)
+        assert len(topo_links) == 1, f"Multi topo s2 and s6 only had 1 link now: {topo_links}"
+        self.net.net.delLink(topo_links[0])
+
+    def test_030_add_interface(self):
+        """Test adding an interface while kytos is running
+        Added:
+            - Link: 01:1 - 03:1
+            - Interface: 01:4 ('s1-eth4')
+        """
+        # Count how many interfaces does Switch 01
+        api_url = f'{KYTOS_API}/topology/v3/'
+        response = requests.get(api_url)
+        data = response.json()
+        s1_intfs_before = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+
+        S1, S3 = self.net.net.get('s1', 's3')
+        self.net.net.addLink(S1, S3, port1=20, port2=20)
+        S1.attach('s1-eth20')
+        S3.attach('s3-eth20')
+        time.sleep(2)
+
+        # Look new interface in the database
+        api_url = f'{KYTOS_API}/topology/v3/'
+        response = requests.get(api_url)
+        data = response.json()
+        s1_intfs_after = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+
+        assert s1_intfs_before + 1 == s1_intfs_after


### PR DESCRIPTION
Closes #423 

### Summary

- Adding interface while kytos is running test is added.
- Previous test was modified to remove a link from Mininet

### Local Tests

### End-to-End Tests
Results from using `topology` [PR](https://github.com/kytos-ng/topology/pull/291) and `of_core` [PR](https://github.com/kytos-ng/of_core/pull/161)
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```
