### PR TITLE
Increased linger time for tests

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -24,6 +24,7 @@ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LINGER_MS =.*/LINGER_MS = 50/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/kafka_events/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates


### PR DESCRIPTION
Closes #419

### Summary

Increased linger time for tests

### Local Tests
N/A

### End-to-End Tests
Ran kafka test 101 times by failing them manually. They all passed
```
+ python3 -m pytest tests/ --reruns 100 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: timeout-2.2.0, rerunfailures-13.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 301 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 21%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR [ 99%]
RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRF          [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```