### PR TITLE
Feat/p4ofswitch

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -24,6 +24,7 @@ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/TIMEOUT = 0.5/TIMEOUT = 3.0/g' $NAPPS_PATH/var/lib/kytos/napps/amlight/sdntrace/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -28,8 +28,10 @@ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' $NAPPS_PA
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' $NAPPS_PATH/etc/kytos/logging.ini
-sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' $NAPPS_PATH/etc/kytos/logging.ini
-echo -e "\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka" >> $NAPPS_PATH/etc/kytos/logging.ini
+if ! grep -q aiokafka $NAPPS_PATH/etc/kytos/logging.ini; then
+	sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' $NAPPS_PATH/etc/kytos/logging.ini
+	echo -e "\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka" >> $NAPPS_PATH/etc/kytos/logging.ini
+fi
 
 test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -37,7 +37,9 @@ test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 scripts/setup_kafka.py 2>/dev/null
+python3 scripts/setup_kafka.py
+
+date
 
 python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 

--- a/scripts/setup_kafka.py
+++ b/scripts/setup_kafka.py
@@ -63,10 +63,15 @@ async def create_topic(admin: AIOKafkaAdminClient, brokers: int) -> None:
     """Attempt to delete and then create 'event_logs'"""
     # 1. Attempt to delete the topic first
     try:
+        print(f"Deleting topic {KAFKA_TOPIC}...")
         await admin.delete_topics([KAFKA_TOPIC])
         # Give broker time to update metadata (crucial step)
-        await asyncio.sleep(2)
-        print(f"Topic {KAFKA_TOPIC} deleted, proceeding to creation.")
+        for _ in range(30):
+            topics = await admin.list_topics()
+            if KAFKA_TOPIC not in topics:
+                print(f"Topic {KAFKA_TOPIC} deleted, proceeding to creation.")
+                break
+            await asyncio.sleep(1)
     except UnknownTopicOrPartitionError:
         pass
     except Exception as exc:

--- a/scripts/setup_kafka.py
+++ b/scripts/setup_kafka.py
@@ -10,7 +10,7 @@ from aiokafka.admin import AIOKafkaAdminClient, NewTopic
 from aiokafka.errors import KafkaConnectionError
 
 KAFKA_BOOTSTRAP_SERVERS = os.environ.get("KAFKA_HOST_ADDR", "localhost:29092")
-KAFKA_TOPIC = "event_logs"
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "event_logs")
 
 def bootstrap_servers_list(bootstrap_servers: str) -> list[str]:
     """Format the given bootstrap servers into ip:port"""
@@ -30,7 +30,7 @@ async def create_admin_client(bootstrap_servers: list[str]) -> AIOKafkaAdminClie
         print("An unknown error has occurred.")
         raise exc
 
-async def validate_cluster(admin: AIOKafkaAdminClient) -> None:
+async def validate_cluster(admin: AIOKafkaAdminClient) -> int:
     """
     Using an admin client, validate that the cluster is healthy and all the nodes are operational.
 
@@ -40,6 +40,7 @@ async def validate_cluster(admin: AIOKafkaAdminClient) -> None:
     try:
         cluster_metadata: dict[str, Any] = await admin.describe_cluster()
         print(f"Cluster info: {cluster_metadata}")
+        return len(cluster_metadata["brokers"])
     except KafkaConnectionError as exc:
         print("Unable to connect to cluster for validation.")
         raise exc
@@ -58,13 +59,31 @@ async def shutdown(admin: AIOKafkaAdminClient) -> None:
         print("An unknown issue occurred while shutting down.")
         raise exc
 
-async def create_topic(admin: AIOKafkaAdminClient) -> None:
-    """Attempt to create 'event_logs'"""
+async def create_topic(admin: AIOKafkaAdminClient, brokers: int) -> None:
+    """Attempt to delete and then create 'event_logs'"""
+    # 1. Attempt to delete the topic first
     try:
-        await admin.create_topics(
-            [NewTopic(KAFKA_TOPIC, num_partitions=3, replication_factor=3)],
+        await admin.delete_topics([KAFKA_TOPIC])
+        # Give broker time to update metadata (crucial step)
+        await asyncio.sleep(2)
+        print(f"Topic {KAFKA_TOPIC} deleted, proceeding to creation.")
+    except UnknownTopicOrPartitionError:
+        pass
+    except Exception as exc:
+        print(f"Error deleting topic: {e}")
+        raise exc
+
+    try:
+        res = await admin.create_topics(
+            [NewTopic(KAFKA_TOPIC, num_partitions=8, replication_factor=brokers)],
             timeout_ms=5000
         )
+        for name, code, msg in res.topic_errors:
+            if code != 0:
+                raise Exception(
+                    f"Topic creation failed for '{name}' err={code}: {msg}"
+                )
+            print(f"Topic {name} created successfully.")
         await asyncio.sleep(2) # Let the topic propagate
     except KafkaConnectionError as exc:
         print("Unable to create topic.")
@@ -84,10 +103,10 @@ async def main() -> None:
     admin = await create_admin_client(bootstrap_servers)
     print("Admin client was successful! Attempting to validate cluster...")
 
-    await validate_cluster(admin)
+    brokers = await validate_cluster(admin)
     print(f"Cluster was successfully validated! Attempting to create topic '{KAFKA_TOPIC}'...")
 
-    await create_topic(admin)
+    await create_topic(admin, brokers)
     print(f"Topic '{KAFKA_TOPIC}' was created! Attempting to close the admin client...")
 
     await shutdown(admin)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,17 +15,15 @@ def pytest_terminal_summary(terminalreporter):
     terminalreporter.section('start/stop times', sep='-', bold=True)
     for stat in terminalreporter.stats.values():
         for report in stat:
-            if (
-                hasattr(report, "outcome")
-                and report.outcome == "rerun"
-                and report.when == "call"
-            ):
+            if not hasattr(report, "outcome"):
+                continue
+            if report.outcome == "rerun" and report.when in ("call", "setup"):
                 terminalreporter.write_line(f"rerun: {report.rerun}")
                 start = datetime.fromtimestamp(report.start)
                 stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))
                 terminalreporter.write_line(f"{report.longrepr}")
-            if hasattr(report, 'failed') and report.failed and report.when == 'call':
+            if report.outcome == "failed" and report.when in ("call", "setup"):
                 start = datetime.fromtimestamp(report.start)
                 stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,8 @@ import os
 import requests
 import hashlib
 
+from collections import defaultdict
+
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
@@ -505,6 +507,29 @@ class NetworkTest:
         else:
             raw_str = ":".join(sorted((intf1, intf2)))
         return hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
+
+    def wait_kytos_buff_low_qsize(self, max_wait=60, qsize_limit=100):
+        wait_count = 0
+        queue_sizes = defaultdict(list)
+        while wait_count < max_wait+5:
+            try:
+                response = requests.get("http://127.0.0.1:8181/api/kytos/core/status/", timeout=3)
+                buf_qsize = response.json()["buffers_qsize"]
+                moving_avg = {}
+                for name, size in buf_qsize.items():
+                    queue_sizes[name].append(size)
+                    if len(queue_sizes[name]) > 5:
+                        moving_avg[name] = sum(queue_sizes[name][-5:]) / 5
+                    else:
+                        moving_avg[name] = qsize_limit+1
+                assert all([size <= qsize_limit for size in moving_avg.values()]), f"{moving_avg=} {buf_qsize=}"
+            except Exception as exc:
+                last_error = str(exc)
+            time.sleep(1)
+            wait_count += 1
+        else:
+            msg = f"Timeout waiting for low buffer queue sizes. Last error: {last_error}"
+            raise Exception(msg)
 
     def restart_kytos_clean(self):
         self.start_controller(clean_config=True, enable_all=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -431,6 +431,10 @@ class NetworkTest:
 
     def wait_switches_connect(self):
         max_wait = 0
+        # update controller UUIDs for OVSSwitch to avoid errors while changing
+        # the controller: no row "xyz" in table Controller
+        for sw in self.net.switches:
+            sw.controllerUUIDs(update=True)
         while any(not sw.connected() for sw in self.net.switches):
             time.sleep(1)
             max_wait += 1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -345,9 +345,10 @@ class NetworkTest:
         self.net.orig_configLinkStatus = self.net.configLinkStatus
         self.net.configLinkStatus = self.configLinkStatus
 
-    def start(self):
+    def start(self, start_controller=True):
         self.net.start()
-        self.start_controller(clean_config=True)
+        if start_controller:
+            self.start_controller(clean_config=True)
 
     def drop_database(self):
         """Drop database."""
@@ -535,7 +536,7 @@ class NetworkTest:
     def restart_kytos_clean(self):
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
-        self.wait_kytos_links(status="UP")
+        self.wait_kytos_links()
 
     def reconnect_switches(self, target="tcp:127.0.0.1:6653",
                            temp_target="tcp:127.0.0.1:6654", wait=True):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -523,6 +523,7 @@ class NetworkTest:
                     else:
                         moving_avg[name] = qsize_limit+1
                 assert all([size <= qsize_limit for size in moving_avg.values()]), f"{moving_avg=} {buf_qsize=}"
+                break
             except Exception as exc:
                 last_error = str(exc)
             time.sleep(1)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -444,7 +444,7 @@ class NetworkTest:
                 link_id = self.create_link_id(link)
                 if link_id:
                     topo_links.append(link_id)
-        while wait_count < 30:
+        while wait_count < 60:
             try:
                 response = requests.get("http://127.0.0.1:8181/api/kytos/topology/v3/links/", timeout=3)
                 links = response.json()["links"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -460,8 +460,8 @@ class NetworkTest:
                 if node_b and intf2.node != node_b:
                     continue
                 if any([
-                    (port1 is not None and not intf.name.endswith(f"eth{port1}"))
-                    (port2 is not None and not intf2.name.endswith(f"eth{port2}"))
+                    port1 is not None and not intf.name.endswith(f"eth{port1}"),
+                    port2 is not None and not intf2.name.endswith(f"eth{port2}"),
                 ]):
                     continue
                 node_a_links.add(intf.link)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -435,31 +435,8 @@ class NetworkTest:
                 status = [(sw.name, sw.connected()) for sw in self.net.switches]
                 raise Exception('Timeout: timed out waiting switches reconnect. Status %s' % status)
 
-    def wait_kytos_links(self):
-        wait_count = 0
-        last_error = ""
-        topo_links = []
-        for link in self.net.links:
-            if link.intf1.node in self.net.switches and link.intf2.node in self.net.switches:
-                link_id = self.create_link_id(link)
-                if link_id:
-                    topo_links.append(link_id)
-        while wait_count < 60:
-            try:
-                response = requests.get("http://127.0.0.1:8181/api/kytos/topology/v3/links/", timeout=3)
-                links = response.json()["links"]
-                assert len(topo_links) == len(links), f"{topo_links=} {links=}"
-                assert all(link_id in links for link_id in topo_links), f"{topo_links=} {links=}"
-                break
-            except Exception as exc:
-                last_error = str(exc)
-            time.sleep(1)
-            wait_count += 1
-        else:
-            msg = f"Timeout waiting for links. Last error: {last_error}"
-            raise Exception(msg)
 
-    def wait_kytos_links2(self, a=None, b=None, port1=None, port2=None, status=None):
+    def wait_kytos_links(self, a=None, b=None, port1=None, port2=None, status=None):
         wait_count = 0
         last_error = ""
         topo_links = []

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -459,6 +459,53 @@ class NetworkTest:
             msg = f"Timeout waiting for links. Last error: {last_error}"
             raise Exception(msg)
 
+    def wait_kytos_links2(self, a=None, b=None, port1=None, port2=None, status=None):
+        wait_count = 0
+        last_error = ""
+        topo_links = []
+        links = self.net.links
+        if a is not None:
+            node_a = self.net.nameToNode.get(a)
+            if not node_a:
+                raise ValueError(f"Invalid node {a}")
+            node_b = None
+            if b is not None:
+                node_b = self.net.nameToNode.get(b)
+                if not node_b:
+                    raise ValueError(f"Invalid node {b}")
+            node_a_links = set()
+            for intf in node_a.intfs.values():
+                if not intf.link:
+                    continue
+                if node_b and intf.link.intf1.node != node_b and intf.link.intf2.node != node_b:
+                    continue
+                # TODO: port1 and port2 ?
+                node_a_links.add(intf.link)
+            links = list(node_a_links)
+        for link in links:
+            if link.intf1.node in self.net.switches and link.intf2.node in self.net.switches:
+                link_id = self.create_link_id(link)
+                if link_id:
+                    topo_links.append(link_id)
+        while wait_count < 60:
+            try:
+                response = requests.get("http://127.0.0.1:8181/api/kytos/topology/v3/links/", timeout=3)
+                links = response.json()["links"]
+                if a is not None:
+                    links = {lid: links[lid] for lid in topo_links if lid in links}
+                assert len(topo_links) == len(links), f"{topo_links=} {links=}"
+                assert all(link_id in links for link_id in topo_links), f"{topo_links=} {links=}"
+                if status is not None:
+                    assert all(links[lid]["status"] == status for lid in topo_links), f"{topo_links} {links=} {status=}"
+                break
+            except Exception as exc:
+                last_error = str(exc)
+            time.sleep(1)
+            wait_count += 1
+        else:
+            msg = f"Timeout waiting for links. Last error: {last_error}"
+            raise Exception(msg)
+
     def create_link_id(self, link):
         dpid1 = link.intf1.node.dpid
         dpid2 = link.intf2.node.dpid

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -515,7 +515,7 @@ class NetworkTest:
         while wait_count < max_wait+period:
             try:
                 response = requests.get("http://127.0.0.1:8181/api/kytos/core/status/", timeout=3)
-                buf_usage = response.json()["buffers_usage"]
+                buf_usage = response.json()["buffers_qsize"]
                 moving_avg = {}
                 for name, size in buf_usage.items():
                     q_usage[name].append(size)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -508,34 +508,34 @@ class NetworkTest:
             raw_str = ":".join(sorted((intf1, intf2)))
         return hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
 
-    def wait_kytos_buff_low_qsize(self, max_wait=60, qsize_limit=100):
+    def wait_kytos_buff_low_usage(self, max_wait=60, usage_limit=50, period=5):
         wait_count = 0
-        queue_sizes = defaultdict(list)
-        while wait_count < max_wait+5:
+        q_usage = defaultdict(list)
+        while wait_count < max_wait+period:
             try:
                 response = requests.get("http://127.0.0.1:8181/api/kytos/core/status/", timeout=3)
-                buf_qsize = response.json()["buffers_qsize"]
+                buf_usage = response.json()["buffers_usage"]
                 moving_avg = {}
-                for name, size in buf_qsize.items():
-                    queue_sizes[name].append(size)
-                    if len(queue_sizes[name]) > 5:
-                        moving_avg[name] = sum(queue_sizes[name][-5:]) / 5
+                for name, size in buf_usage.items():
+                    q_usage[name].append(size)
+                    if len(q_usage[name]) > period:
+                        moving_avg[name] = sum(q_usage[name][-period:]) / period
                     else:
-                        moving_avg[name] = qsize_limit+1
-                assert all([size <= qsize_limit for size in moving_avg.values()]), f"{moving_avg=} {buf_qsize=}"
+                        moving_avg[name] = usage_limit+1
+                assert all([usage <= usage_limit for usage in moving_avg.values()]), f"{moving_avg=} {buf_usage=}"
                 break
             except Exception as exc:
                 last_error = str(exc)
             time.sleep(1)
             wait_count += 1
         else:
-            msg = f"Timeout waiting for low buffer queue sizes. Last error: {last_error}"
+            msg = f"Timeout waiting for low buffer queue usage. Last error: {last_error}"
             raise Exception(msg)
 
     def restart_kytos_clean(self):
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
-        self.wait_kytos_links()
+        self.wait_kytos_links(status="UP")
 
     def reconnect_switches(self, target="tcp:127.0.0.1:6653",
                            temp_target="tcp:127.0.0.1:6654", wait=True):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,6 +13,7 @@ from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
 from tests.noviswitch import NoviSwitch
+from tests.p4ofswitch import P4OfSwitch
 
 BASE_ENV = os.environ.get('VIRTUAL_ENV', None) or '/'
 
@@ -25,12 +26,16 @@ NoviSwitch.orig_dpctl = NoviSwitch.dpctl
 NoviSwitch.dpctl = dpctl_wrapper
 OVSSwitch.orig_dpctl = OVSSwitch.dpctl
 OVSSwitch.dpctl = dpctl_wrapper
+P4OfSwitch.orig_dpctl = P4OfSwitch.dpctl
+P4OfSwitch.dpctl = dpctl_wrapper
 
 class SwitchFactory:
     def __new__(cls, *args, **kwargs):
         cls_name = os.environ.get('SWITCH_CLASS')
         if cls_name == "NoviSwitch" and NoviSwitch.is_available():
             return NoviSwitch(*args, **kwargs)
+        if cls_name == "P4OfSwitch":
+            return P4OfSwitch(*args, **kwargs)
         return OVSSwitch(*args, **kwargs)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -457,10 +457,10 @@ class NetworkTest:
                 intf2 = intf.link.intf2 if intf.link.intf1 == intf else intf.link.intf1
                 if node_b and intf2.node != node_b:
                     continue
-                if (
-                    port1 is not None and intf.name.endswith(f"eth{port1}") and
-                    port2 is not None and intf2.name.endswith(f"eth{port2}")
-                ):
+                if any([
+                    (port1 is not None and not intf.name.endswith(f"eth{port1}"))
+                    (port2 is not None and not intf2.name.endswith(f"eth{port2}"))
+                ]):
                     continue
                 node_a_links.add(intf.link)
             links = list(node_a_links)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -519,7 +519,7 @@ class NetworkTest:
         else:
             connections = node_a.connectionsTo(node_b)
         if len(connections) == 0:
-            error(f"src and dst not connected: {src} {dst}\n")
+            error(f"src and dst not connected: {a} {b}\n")
             return
         # for NoviSwitch hosts, before changing the status of the veth interfaces
         # we need to actually change the status of the interface on the switch to

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -454,9 +454,14 @@ class NetworkTest:
             for intf in node_a.intfs.values():
                 if not intf.link:
                     continue
-                if node_b and intf.link.intf1.node != node_b and intf.link.intf2.node != node_b:
+                intf2 = intf.link.intf2 if intf.link.intf1 == intf else intf.link.intf1
+                if node_b and intf2.node != node_b:
                     continue
-                # TODO: port1 and port2 ?
+                if (
+                    port1 is not None and intf.name.endswith(f"eth{port1}") and
+                    port2 is not None and intf2.name.endswith(f"eth{port2}")
+                ):
+                    continue
                 node_a_links.add(intf.link)
             links = list(node_a_links)
         for link in links:

--- a/tests/noviswitch.py
+++ b/tests/noviswitch.py
@@ -623,5 +623,10 @@ class NoviSwitch(Switch):
             cmd = "set config port portno %d portdown %s" % (portno, portdown)
             self.novi_cmd(cmd)
 
+    def get_all_of_ports(self):
+        """Get all OpenFlow port numbers."""
+        ports = self.dpctl("dump-ports")
+        return list(map(int, re.findall(r" port ([0-9]+):", ports)))
+
 
 addCleanupCallback(NoviSwitch.batch_cleanup)

--- a/tests/noviswitch.py
+++ b/tests/noviswitch.py
@@ -625,7 +625,7 @@ class NoviSwitch(Switch):
 
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
-        ports = self.dpctl("dump-ports")
+        ports = self.dpctl("dump-ports --no-names")
         return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))
 
 

--- a/tests/noviswitch.py
+++ b/tests/noviswitch.py
@@ -626,7 +626,7 @@ class NoviSwitch(Switch):
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
         ports = self.dpctl("dump-ports")
-        return list(map(int, re.findall(r" port ([0-9]+):", ports)))
+        return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))
 
 
 addCleanupCallback(NoviSwitch.batch_cleanup)

--- a/tests/noviswitch.py
+++ b/tests/noviswitch.py
@@ -626,7 +626,7 @@ class NoviSwitch(Switch):
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
         ports = self.dpctl("dump-ports --no-names")
-        return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))
+        return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))
 
 
 addCleanupCallback(NoviSwitch.batch_cleanup)

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -7,6 +7,21 @@ from mininet.log import error
 
 P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
 
+MYLOCALIP = os.environ.get("MYLOCALIP")
+if os.environ.get("SWITCH_CLASS") == "P4OfSwitch" and not MYLOCALIP:
+    try:
+        stream = os.popen("ip -j route get 8.8.8.8 | jq -r '.[0].prefsrc'")
+        output = stream.read().strip()
+    except:
+        output = ""
+    if not output:
+        raise ValueError(
+            "Could not identify the Local IP. Please define MYLOCALIP env var"
+            " or check pref ip default router"
+        )
+    MYLOCALIP = output
+
+
 class P4OfSwitch(DockerSwitch):
     """P4OfSwitch (P4OfAgent + AmLight P4 pipeline)."""
 
@@ -48,7 +63,7 @@ class P4OfSwitch(DockerSwitch):
         i = 0
         for c in controllers:
             i += 1
-            c_ip = c.IP()
+            c_ip = c.IP() if c.IP() not in ["127.0.0.1"] else MYLOCALIP
             c_port = c.port
             self.controllers.append((c_ip, c_port))
             cmd_str = (
@@ -96,6 +111,7 @@ class P4OfSwitch(DockerSwitch):
             for c in args[2:]:
                 i += 1
                 proto, ip, port = c.split(":")
+                ip = ip if ip not in ["127.0.0.1"] else MYLOCALIP
                 self.controllers.append((ip, port))
                 cmd_str = (
                     f"p4ofagent set config controller --ip {ip} "

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -167,4 +167,4 @@ class P4OfSwitch(DockerSwitch):
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
         ports = self.dpctl("dump-ports")
-        return list(map(int, re.findall(r" port ([0-9]+):", ports)))
+        return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -1,0 +1,113 @@
+"""P4OfSwitch"""
+
+import os
+from mininet.nodelib import DockerSwitch
+from mininet.log import error
+
+P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
+
+class P4OfSwitch(DockerSwitch):
+    """P4OfSwitch (P4OfAgent + AmLight P4 pipeline)."""
+
+    def __init__(self, name, **kwargs):
+        """create p4ofswitch instance."""
+        self.arch = P4OFSWITCH_ARCH
+        DockerSwitch.__init__(
+            self,
+            name,
+            image="amlight/p4ofswitch:latest",
+            pull="always",
+            env=[f"ARCH={self.arch}"],
+        )
+
+    def wait_start(self):
+        """Wait until switch has started."""
+        for i in range(300):
+            output = self.cmd("p4ofagent show status system-health")
+            if "System internal status : OK" in output:
+                return True
+            time.sleep(1)
+        raise TimeoutError(f"timeout waiting for switch {self.name} to start")
+
+    def start(self, controllers):
+        """Start p4ofswitch instance."""
+        self.wait_start()
+
+        # configure DPID
+        dpid = "{:016x}".format(int(self.dpid, 16))
+        dpid = ":".join([dpid[i:i+2] for i in range(0, 16, 2)])
+        output = self.cmd(f"p4ofagent set config switch dpid {dpid}")
+        if output:
+            raise ValueError(
+                f"Failed to configure DPID {dpid} for {self.name}: {output}"
+            )
+
+        # configure controllers
+        i = 0
+        for c in controllers:
+            i += 1
+            c_ip = c.IP()
+            c_port = c.port
+            self.controllers.append((c_ip, c_port))
+            cmd_str = (
+                f"p4ofagent set config controller --ip {c_ip} --port {c_port}"
+                f" --name c{i} --priority {1000+i}"
+            )
+            output = self.cmd(cmd_str)
+            if output:
+                error(
+                    f"\nFailed to run node={self.name} cmd={cmd_str}: {output}"
+                )
+        
+    def connected(self):
+        output = self.cmd("p4ofagent show config controller")
+        return "Is connected: True" in output
+
+    def dpctl(self, *args):
+        "Run dpctl command"
+        cmd = f"ovs-ofctl {args[0]} -O OpenFlow13 tcp:127.0.0.1:6653 "
+        cmd += " ".join(args[1:])
+        return self.cmd(cmd)
+
+    def reset_controller(self):
+        """Reset the controller connection."""
+        cmd = "p4ofagent set status controller all --reset"
+        return self.cmd(cmd)
+
+    def vsctl(self, *args):
+        """Run vsctl command (try to map from ovs-vsctl)"""
+        if len(args) == 1:
+            args = args[0].split(" ")
+        if args[0] == "del-controller":
+            cmd = "p4ofagent del config controller all"
+            output = self.cmd(cmd)
+            if output:
+                error(f"\nFailed to run name={self.name} cmd={cmd}: {output}")
+            self.controllers = []
+        elif args[0] == "set-controller":
+            cmd = "p4ofagent del config controller all"
+            output = self.cmd(cmd)
+            if output:
+                error(f"\nFailed to run name={self.name} cmd={cmd}: {output}")
+            self.controllers = []
+            i = 0
+            for c in controllers:
+                i += 1
+                c_ip = c.IP()
+                c_port = c.port
+                self.controllers.append((c_ip, c_port))
+                cmd_str = (
+                    f"p4ofagent set config controller --ip {c_ip} "
+                    f"--port {c_port} --name c{i} --priority {1000+i}"
+                )
+                output = self.cmd(cmd_str)
+                if output:
+                    error(
+                        f"\nFailed to run node={self.name} "
+                        f"cmd={cmd_str}: {output}"
+                    )
+        else:
+            logger.error("vsctl command not implemented: %s" % args)
+
+    def controllerUUIDs(self, *args, **kwargs):
+        pass

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 from mininet.nodelib import DockerSwitch
-from mininet.log import error
+from mininet.log import error, info
 
 P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
 
@@ -164,6 +164,10 @@ class P4OfSwitch(DockerSwitch):
 
     def controllerUUIDs(self, *args, **kwargs):
         pass
+
+    def detach(self, intf):
+        """Disconnect a data port"""
+        info(f"Dettach intf {intf} from {self.name} - nothing to do")
 
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -1,6 +1,7 @@
 """P4OfSwitch"""
 
 import os
+import time
 from mininet.nodelib import DockerSwitch
 from mininet.log import error
 

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -176,8 +176,8 @@ class P4OfSwitch(DockerSwitch):
         return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))
 
     @classmethod
-    def batchShutdown( cls, switches, run=errRun ):
+    def batchShutdown( cls, switches, run=quietRun ):
         """Shut down a list of P4OfSwitch switches"""
-        quietRun("docker rm -f " + " ".join([sw.name for sw in switches]))
+        run("docker rm -f " + " ".join([sw.name for sw in switches]))
         for sw in switches:
             sw.terminate()

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -5,6 +5,7 @@ import re
 import time
 from mininet.nodelib import DockerSwitch
 from mininet.log import error, info
+from mininet.util import quietRun
 
 P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
 
@@ -173,3 +174,10 @@ class P4OfSwitch(DockerSwitch):
         """Get all OpenFlow port numbers."""
         ports = self.dpctl("dump-ports --no-names")
         return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))
+
+    @classmethod
+    def batchShutdown( cls, switches, run=errRun ):
+        """Shut down a list of P4OfSwitch switches"""
+        quietRun("docker rm -f " + " ".join([sw.name for sw in switches]))
+        for sw in switches:
+            sw.terminate()

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -1,6 +1,7 @@
 """P4OfSwitch"""
 
 import os
+import re
 import time
 from mininet.nodelib import DockerSwitch
 from mininet.log import error
@@ -29,12 +30,17 @@ class P4OfSwitch(DockerSwitch):
         """create p4ofswitch instance."""
         self.arch = P4OFSWITCH_ARCH
         self.controllers = []
-        DockerSwitch.__init__(
-            self,
+        super().__init__(
             name,
             image="amlight/p4ofswitch:latest",
             pull="always",
-            env=[f"ARCH={self.arch}"],
+            env=[
+                f"ARCH={self.arch}",
+                "MIN_RETRY_DELAY=2",
+                "MAX_RETRY_DELAY=4",
+                "DEFAULT_PORTDOWN=on",
+            ],
+            volume=[f"/tmp/{name}-logs:/var/log"],
         )
 
     def wait_start(self):
@@ -45,6 +51,19 @@ class P4OfSwitch(DockerSwitch):
                 return True
             time.sleep(1)
         raise TimeoutError(f"timeout waiting for switch {self.name} to start")
+
+    def intf_name_to_number(self, intf_name):
+        """Convert interface name into number: s1-eth1 -> 1."""
+        nums = re.findall(r"\d+$", intf_name)
+        return int(nums[0])
+
+    def setup_intf(self, intf):
+        """Setup the interface by enabling it and other confis."""
+        portno = self.intf_name_to_number(intf.name)
+        cmd = f"p4ofagent set config port portno {portno} --portdown off"
+        output = self.cmd(cmd)
+        if output:
+            error(f"Failed to run node={self.name} cmd={cmd}: {outpt}")
 
     def start(self, controllers):
         """Start p4ofswitch instance."""
@@ -58,6 +77,11 @@ class P4OfSwitch(DockerSwitch):
             raise ValueError(
                 f"Failed to configure DPID {dpid} for {self.name}: {output}"
             )
+
+        # enable ports in use
+        for intf in self.intfs.values():
+            if intf.link:
+                self.setup_intf(intf)
 
         # configure controllers
         i = 0
@@ -85,6 +109,14 @@ class P4OfSwitch(DockerSwitch):
         cmd = f"ovs-ofctl {args[0]} -O OpenFlow13 tcp:127.0.0.1:6653 "
         cmd += " ".join(args[1:])
         return self.cmd(cmd)
+
+    def attach(self, intfName):
+        """Connect a data port"""
+        intf = self.nameToIntf.get(intfName)
+        if not intf:
+            error(f"Attached unknown intf {intfName} to {self.name}. Ignoring")
+            return
+        self.setup_intf(intf)
 
     def reset_controller(self):
         """Reset the controller connection."""

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -166,5 +166,5 @@ class P4OfSwitch(DockerSwitch):
 
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
-        ports = self.dpctl("dump-ports")
+        ports = self.dpctl("dump-ports --no-names")
         return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -167,4 +167,4 @@ class P4OfSwitch(DockerSwitch):
     def get_all_of_ports(self):
         """Get all OpenFlow port numbers."""
         ports = self.dpctl("dump-ports --no-names")
-        return list(map(int, re.findall(r"\sport\s+([0-9]+)\s", ports)))
+        return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -163,3 +163,8 @@ class P4OfSwitch(DockerSwitch):
 
     def controllerUUIDs(self, *args, **kwargs):
         pass
+
+    def get_all_of_ports(self):
+        """Get all OpenFlow port numbers."""
+        ports = self.dpctl("dump-ports")
+        return list(map(int, re.findall(r" port ([0-9]+):", ports)))

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -181,3 +181,4 @@ class P4OfSwitch(DockerSwitch):
         run("docker rm -f " + " ".join([sw.name for sw in switches]))
         for sw in switches:
             sw.terminate()
+        return switches

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -13,6 +13,7 @@ class P4OfSwitch(DockerSwitch):
     def __init__(self, name, **kwargs):
         """create p4ofswitch instance."""
         self.arch = P4OFSWITCH_ARCH
+        self.controllers = []
         DockerSwitch.__init__(
             self,
             name,
@@ -92,14 +93,13 @@ class P4OfSwitch(DockerSwitch):
                 error(f"\nFailed to run name={self.name} cmd={cmd}: {output}")
             self.controllers = []
             i = 0
-            for c in controllers:
+            for c in args[2:]:
                 i += 1
-                c_ip = c.IP()
-                c_port = c.port
-                self.controllers.append((c_ip, c_port))
+                proto, ip, port = c.split(":")
+                self.controllers.append((ip, port))
                 cmd_str = (
-                    f"p4ofagent set config controller --ip {c_ip} "
-                    f"--port {c_port} --name c{i} --priority {1000+i}"
+                    f"p4ofagent set config controller --ip {ip} "
+                    f"--port {port} --name c{i} --priority {1000+i}"
                 )
                 output = self.cmd(cmd_str)
                 if output:

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -40,6 +40,7 @@ class P4OfSwitch(DockerSwitch):
                 "MAX_RETRY_DELAY=4",
             ],
             volume=[f"/tmp/{name}-logs:/var/log"],
+            **kwargs,
         )
 
     def wait_start(self):

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -38,7 +38,6 @@ class P4OfSwitch(DockerSwitch):
                 f"ARCH={self.arch}",
                 "MIN_RETRY_DELAY=2",
                 "MAX_RETRY_DELAY=4",
-                "DEFAULT_PORTDOWN=on",
             ],
             volume=[f"/tmp/{name}-logs:/var/log"],
         )
@@ -78,7 +77,11 @@ class P4OfSwitch(DockerSwitch):
                 f"Failed to configure DPID {dpid} for {self.name}: {output}"
             )
 
-        # enable ports in use
+        # disable all ports and enable ports in use
+        cmd = "p4ofagent --timeout 120 set config port portno all --portdown on"
+        output = self.cmd(cmd)
+        if output:
+            error(f"Failed to run node={self.name} cmd={cmd}: {outpt}")
         for intf in self.intfs.values():
             if intf.link:
                 self.setup_intf(intf)

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -104,7 +104,7 @@ class P4OfSwitch(DockerSwitch):
                 error(
                     f"\nFailed to run node={self.name} cmd={cmd_str}: {output}"
                 )
-        
+
     def connected(self):
         output = self.cmd("p4ofagent show config controller")
         return "Is connected: True" in output

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -317,14 +317,14 @@ class TestE2ETopology:
         # Noviflow and P4OfSwitch switches does not create a new interface, but
         # port 20 should be active now.
         if os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"):
-            for intf in memo_intfs_before:
-                if intf["id"] == "00:00:00:00:00:00:00:01:20":
+            for intf_id, intf in memo_intfs_before.items():
+                if intf_id == "00:00:00:00:00:00:00:01:20":
                     assert intf["active"] == False, f"should be down: {intf}"
                     break
             else:
                 pytest.fail(f"intf not found on sw1 before {memo_intfs_after}")
-            for intf in memo_intfs_after:
-                if intf["id"] == "00:00:00:00:00:00:00:01:20":
+            for intf_id, intf in memo_intfs_after.items():
+                if intf_id == "00:00:00:00:00:00:00:01:20":
                     assert intf["active"] == True, f"should be up: {intf}"
                     break
             else:

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -280,13 +280,13 @@ class TestE2ETopology:
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        memo_intfs_before = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_before = data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"]
 
         s1_db = self.net.db.switches.find({"id":"00:00:00:00:00:00:00:01"})
         s1_docu = list(s1_db)
         assert len(s1_docu) == 1, "Switch 1 not found"
         db_intfs_before = len(s1_docu[0]["interfaces"])
-        assert memo_intfs_before == db_intfs_before
+        assert len(memo_intfs_before) == db_intfs_before
 
         # Add interface to s1 and s3
         S1, S3 = self.net.net.get('s1', 's3')
@@ -300,13 +300,35 @@ class TestE2ETopology:
         s1_docu = list(s1_db)
         assert len(s1_docu) == 1, "Switch 1 not found"
         db_intfs_after = len(s1_docu[0]["interfaces"])
-        assert db_intfs_after == db_intfs_before + 1
+
+        # Noviflow and P4OfSwitch switches does not actually create a new
+        # interface here. They will create a new interface when adding a LAG
+        # logical port or creating a breakdown, but we will have another test
+        # for that
+        if os.environ.get("SWITCH_CLASS") not in ("NoviSwitch", "P4OfSwitch"):
+            assert db_intfs_after == db_intfs_before + 1
 
         # Look for new interface in the memory
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        memo_intfs_after = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_after = data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"]
 
-        assert memo_intfs_after == memo_intfs_before + 1
-        assert db_intfs_after == memo_intfs_after
+        # Noviflow and P4OfSwitch switches does not create a new interface, but
+        # port 20 should be active now.
+        if os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"):
+            for intf in memo_intfs_before:
+                if intf["id"] == "00:00:00:00:00:00:00:01:20":
+                    assert intf["active"] == False, f"should be down: {intf}"
+                    break
+            else:
+                pytest.fail(f"intf not found on sw1 before {memo_intfs_after}")
+            for intf in memo_intfs_after:
+                if intf["id"] == "00:00:00:00:00:00:00:01:20":
+                    assert intf["active"] == True, f"should be up: {intf}"
+                    break
+            else:
+                pytest.fail(f"intf not found on sw1 after {memo_intfs_after}")
+        else:
+            assert len(memo_intfs_after) == len(memo_intfs_before) + 1
+        assert db_intfs_after == len(memo_intfs_after)

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -33,7 +33,7 @@ class TestE2ETopology:
         cls.net.stop()
 
     @pytest.mark.skipif(
-        os.environ.get("SWITCH_CLASS") == "NoviSwitch",
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
         reason="NoviSwitch does not support interface removal",
     )
     def test_010_delete_interface_automatically(self):
@@ -171,7 +171,7 @@ class TestE2ETopology:
         assert response.status_code == 200, f"{response.text}, tries: {counter_tries}"
 
     @pytest.mark.skipif(
-        os.environ.get("SWITCH_CLASS") == "NoviSwitch",
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
         reason="NoviSwitch does not support interface removal",
     )
     def test_025_delete_interface(self):

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -417,6 +417,8 @@ class TestE2EMefEline:
         response = requests.patch(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
+        time.sleep(5)
+
         # Check for VLAN 999
         api_url = f'{KYTOS_API}/topology/v3/interfaces/tag_ranges'
         response = requests.get(api_url)

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -44,7 +44,7 @@ class TestE2EMefEline:
         # Wait a few seconds to kytos execute LLDP
         time.sleep(10)
 
-    def wait_sdntrace_result(self, trace_id:int, timeout=11):
+    def wait_sdntrace_result(self, trace_id:int, timeout=30):
         """Wait until sdntrace finishes."""
         wait_count = 0
         while wait_count < timeout:
@@ -174,7 +174,7 @@ class TestE2EMefEline:
         trace_id = self.do_sdntrace('00:00:00:00:00:00:00:16', 2, 100)
         result = self.wait_sdntrace_result(trace_id)
 
-        assert len(result) == 7
+        assert len(result) == 7, str(result)
         assert result[0]["dpid"] == "00:00:00:00:00:00:00:16"
         assert result[1]["dpid"] == "00:00:00:00:00:00:00:15"
         assert result[2]["dpid"] == "00:00:00:00:00:00:00:12"

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -35,15 +35,6 @@ class TestE2EMefEline:
     def teardown_class(cls):
         cls.net.stop()
 
-    def restart(self, _clean_config=False, _enable_all=True):
-        # Start the controller setting an environment in which the setting is
-        # preserved (persistence) and avoid the default enabling of all elements
-        self.net.start_controller(clean_config=_clean_config, enable_all=_enable_all)
-        self.net.wait_switches_connect()
-
-        # Wait a few seconds to kytos execute LLDP
-        time.sleep(10)
-
     def wait_sdntrace_result(self, trace_id:int, timeout=30):
         """Wait until sdntrace finishes."""
         wait_count = 0
@@ -350,10 +341,9 @@ class TestE2EMefEline:
         assert not evc_content["current_path"]
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
-        time.sleep(5)
+        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        #time.sleep(5)
-        self.net.net.wait_kytos_links2('Ampath1', 'Ampath3', status="UP")
+        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         primary_path = evc_content['primary_path']
@@ -376,7 +366,7 @@ class TestE2EMefEline:
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
         time.sleep(10)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        time.sleep(5)
+        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         backup_path = evc_content['backup_path']
@@ -390,8 +380,7 @@ class TestE2EMefEline:
     def test_030_EVC_path_disjointness(self):
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
-        #time.sleep(5)
-        self.net.net.wait_kytos_links2('Ampath1', 'SoL2', status="DOWN")
+        self.net.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
                        uni_z='00:00:00:00:00:00:00:11:16',
@@ -420,4 +409,3 @@ class TestE2EMefEline:
         ]
         assert len(failover_path) == len(expected_failover_path)
         assert failover_path == expected_failover_path
-        self.net.net.configLinkStatus('Ampath1', 'SoL2', 'up')

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -21,13 +21,14 @@ class TestE2EMefEline:
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()
+        self.net.wait_kytos_links(status="UP")
         self.net.wait_kytos_buff_low_usage()
         time.sleep(5)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='amlight')
-        cls.net.start()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -352,7 +352,8 @@ class TestE2EMefEline:
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
         time.sleep(5)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        time.sleep(5)
+        #time.sleep(5)
+        self.net.net.wait_kytos_links2('Ampath1', 'Ampath3', status="UP")
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         primary_path = evc_content['primary_path']
@@ -389,7 +390,8 @@ class TestE2EMefEline:
     def test_030_EVC_path_disjointness(self):
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
-        time.sleep(5)
+        #time.sleep(5)
+        self.net.net.wait_kytos_links2('Ampath1', 'SoL2', status="DOWN")
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
                        uni_z='00:00:00:00:00:00:00:11:16',

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -21,7 +21,8 @@ class TestE2EMefEline:
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()
-        time.sleep(10)
+        self.net.wait_kytos_links(status="UP")
+        #time.sleep(10)
 
     @classmethod
     def setup_class(cls):
@@ -381,6 +382,7 @@ class TestE2EMefEline:
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
         self.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
+        self.net.wait_kytos_buff_low_qsize()
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
                        uni_z='00:00:00:00:00:00:00:11:16',

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -22,7 +22,7 @@ class TestE2EMefEline:
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()
         self.net.wait_kytos_links(status="UP")
-        #time.sleep(10)
+        time.sleep(5)
 
     @classmethod
     def setup_class(cls):
@@ -343,8 +343,10 @@ class TestE2EMefEline:
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
         self.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
+        time.sleep(5)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
         self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
+        time.sleep(5)
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         primary_path = evc_content['primary_path']
@@ -368,6 +370,7 @@ class TestE2EMefEline:
         time.sleep(10)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
         self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
+        time.sleep(5)
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         backup_path = evc_content['backup_path']
@@ -383,6 +386,7 @@ class TestE2EMefEline:
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
         self.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
         self.net.wait_kytos_buff_low_qsize()
+        time.sleep(5)
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
                        uni_z='00:00:00:00:00:00:00:11:16',

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -341,9 +341,9 @@ class TestE2EMefEline:
         assert not evc_content["current_path"]
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
-        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
+        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
+        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         primary_path = evc_content['primary_path']
@@ -366,7 +366,7 @@ class TestE2EMefEline:
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
         time.sleep(10)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        self.net.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
+        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
         backup_path = evc_content['backup_path']
@@ -380,7 +380,7 @@ class TestE2EMefEline:
     def test_030_EVC_path_disjointness(self):
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
-        self.net.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
+        self.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
                        uni_z='00:00:00:00:00:00:00:11:16',

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -21,16 +21,13 @@ class TestE2EMefEline:
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()
-        self.net.wait_kytos_links(status="UP")
+        self.net.wait_kytos_buff_low_usage()
         time.sleep(5)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='amlight')
         cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
 
     @classmethod
     def teardown_class(cls):
@@ -342,10 +339,11 @@ class TestE2EMefEline:
         assert not evc_content["current_path"]
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
+        self.net.wait_switches_connect()
         self.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
         time.sleep(5)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
-        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
+        self.net.wait_kytos_links(status="UP")
         time.sleep(5)
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
@@ -385,7 +383,6 @@ class TestE2EMefEline:
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
         self.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
-        self.net.wait_kytos_buff_low_qsize()
         time.sleep(5)
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -373,7 +373,7 @@ class TestE2EMefEline:
         self.net.net.configLinkStatus('Ampath1', 'Ampath4', 'down')
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
-        time.sleep(5)
+        time.sleep(10)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
         time.sleep(5)
         evc_content = self.get_evc_data(evc)

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -241,6 +241,8 @@ class TestE2EMefEline:
         assert response.status_code == 201, response.text
         assert 'circuit_id' in response.json()
 
+        time.sleep(5)
+
         # Verify if EVC tag has been allocated
         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
         response = requests.get(topo_url)

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -345,6 +345,8 @@ class TestE2EMefEline:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        time.sleep(5)
+
         intf_id = '00:00:00:00:00:00:00:01:1'
         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
         response = requests.get(api_url)
@@ -444,6 +446,8 @@ class TestE2EMefEline:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         circuit_id = response.json()["circuit_id"]
+
+        time.sleep(5)
 
         expected = [[1, 9], [16, 3798], [3800, 4094]]
         intf_id = '00:00:00:00:00:00:00:01:1'

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -1,5 +1,6 @@
 import json
 import time
+import re
 
 import requests
 
@@ -831,6 +832,7 @@ class TestE2EFlowManager:
         payload = {
             "flows": [
                 {
+                    "cookie": 0x99,
                     "priority": 10,
                     "idle_timeout": 360,
                     "hard_timeout": 1200,
@@ -858,13 +860,15 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
-        assert 'in_port=1' in flows_s1
+        assert len(re.findall("cookie=0x99.*in_port=1 .*output:2", flows_s1)) == 1, flows_s1
 
         # Modify the actions and verify its modification
-        s1.dpctl('mod-flows', 'actions=output:3')
+        # we use output:7 which is a port not in use, to avoid further
+        # problems with loop detection and mismatch links
+        s1.dpctl('mod-flows', 'actions=output:7')
         flows_s1 = s1.dpctl('dump-flows')
         assert 'actions=output:2' not in flows_s1
-        assert 'actions=output:3' in flows_s1
+        assert 'actions=output:7' in flows_s1
 
         if restart_kytos:
             # restart controller keeping configuration
@@ -879,8 +883,8 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
-        assert 'actions=output:3' not in flows_s1
-        assert 'in_port=1' in flows_s1
+        assert 'actions=output:7' not in flows_s1
+        assert len(re.findall("cookie=0x99.*in_port=1 .*output:2", flows_s1)) == 1, flows_s1
 
     def test_040_replace_action_flow(self):
         self.replace_action_flow()

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -78,7 +78,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that the flow that was sent is on /v2/stored_flows
         dpid = "00:00:00:00:00:00:00:01"
@@ -139,7 +142,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         sw = self.net.net.get("s1")
         flows_sw = sw.dpctl("dump-flows")
@@ -256,7 +262,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
@@ -351,7 +360,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}&cookie_range=1&cookie_range=3'
         response = requests.get(stored_flows)
@@ -406,7 +418,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -458,7 +473,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that flows are soft deleted on /v2/stored_flows
         response = requests.get(
@@ -482,13 +500,13 @@ class TestE2EFlowManager:
         for i in range(1, 4):
             dpid = f"00:00:00:00:00:00:00:0{i}"
             assert dpid in data
-            assert len(data[dpid]["flows"]) == BASIC_FLOWS, data[dpid]
+            assert len(data[dpid]["flows"]) == BASIC_FLOWS, f"dpid={dpid} data={data[dpid]}"
 
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
             flows_sw = sw.dpctl('dump-flows')
             assert len(flows_sw.splitlines()) == BASIC_FLOWS, flows_sw
-            assert 'actions=output:2' not in flows_sw
+            assert 'actions=output:2' not in flows_sw, flows_sw
 
     def test_026_delete_flows_cookie_mask_range(self):
         """Test deleting flows with cookie range mask and persistence."""""
@@ -558,7 +576,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that flows are soft deleted on /v2/stored_flows
         response = requests.get(

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -1068,6 +1068,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] in {"installed", "pending"}
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1107,6 +1109,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] == "deleted"
 
+        time.sleep(5)
+
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
@@ -1129,6 +1133,8 @@ class TestE2EFlowManager:
                       headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1145,6 +1151,9 @@ class TestE2EFlowManager:
         response = requests.delete(api_url, data=json.dumps(payload),
                       headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
+
+        time.sleep(5)
+
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
@@ -1168,6 +1177,8 @@ class TestE2EFlowManager:
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
+
+        time.sleep(5)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -1230,6 +1241,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] in {"installed", "pending"}
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1268,6 +1281,8 @@ class TestE2EFlowManager:
         for sw_flows, length in test_list:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] == "deleted", flow
+
+        time.sleep(5)
 
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -144,16 +144,16 @@ class TestE2EOfLLDP:
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
         rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
-        time.sleep(10)
+        time.sleep(15)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
         rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
 
-        assert rx_stats_h11_2 == rx_stats_h11 \
-            and rx_stats_h12_2 == rx_stats_h12 \
-            and rx_stats_h2_2 == rx_stats_h2 \
-            and rx_stats_h3_2 == rx_stats_h3
+        assert rx_stats_h11_2 == rx_stats_h11
+        assert rx_stats_h12_2 == rx_stats_h12
+        assert rx_stats_h2_2 == rx_stats_h2
+        assert rx_stats_h3_2 == rx_stats_h3
 
         # restart kytos and check if lldp remains disabled
         self.net.start_controller(clean_config=False, enable_all=False)
@@ -248,4 +248,4 @@ class TestE2EOfLLDP:
         delta_pps_2 = rx_stats_h11_2 - rx_stats_h11
 
         # the delta pps now should be around 30, because the interval is every 1s
-        assert delta_pps_2 > delta_pps + 15
+        assert delta_pps_2 > 2*delta_pps

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -139,6 +139,9 @@ class TestE2EOfLLDP:
         data = response.json()
         assert set(data["interfaces"]) == set(expected_interfaces)
 
+        # wait LLDP message that were being sent before disabling
+        time.sleep(5)
+
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -56,14 +56,24 @@ class TestE2EOfLLDP:
         # s1 lo:  s1-eth1:h11-eth0 s1-eth2:h12-eth0 s1-eth3:s2-eth2 s1-eth4:s3-eth3
         # s2 lo:  s2-eth1:h2-eth0 s2-eth2:s1-eth3 s2-eth3:s3-eth2
         # s3 lo:  s3-eth1:h3-eth0 s3-eth2:s2-eth3 s3-eth3:s1-eth4
-        expected_interfaces = [
+        expected_interfaces = set([
                 "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:01:3",
                 "00:00:00:00:00:00:00:01:4", "00:00:00:00:00:00:00:01:4294967294",
                 "00:00:00:00:00:00:00:02:1", "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
                 "00:00:00:00:00:00:00:02:4294967294",
                 "00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3",
                 "00:00:00:00:00:00:00:03:4294967294"
-        ]
+        ])
+        # some switches have more interfaces than the ones configured by
+        # mininet (ex: Noviflow switches, P4OfSwitch)
+        for sw_name in ["s1", "s2", "s3"]:
+            sw = self.net.net.get(sw_name)
+            if hasattr(sw, "get_all_of_ports"):
+                ports = sw.get_all_of_ports()
+                dpid = ":".join([sw.dpid[i:i+2] for i in range(0, 16, 2)])
+                intf_ids = [f"{dpid}:{port}" for port in ports]
+                expected_interfaces.update(intf_ids)
+
         assert set(data["interfaces"]) == set(expected_interfaces)
 
         # make sure the interfaces are actually receiving LLDP
@@ -103,6 +113,22 @@ class TestE2EOfLLDP:
                 "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
                 "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3"
         ]
+        # some switches have more interfaces than the ones configured by
+        # mininet (ex: Noviflow switches, P4OfSwitch)
+        extra_intfs = []
+        for sw_name in ["s1", "s2", "s3"]:
+            sw = self.net.net.get(sw_name)
+            if hasattr(sw, "get_all_of_ports"):
+                ports = sw.get_all_of_ports()
+                dpid = ":".join([sw.dpid[i:i+2] for i in range(0, 16, 2)])
+                for port in ports:
+                    intf_id = f"{dpid}:{port}"
+                    if intf_id in expected_interfaces:
+                        continue
+                    if intf_id in payload["interfaces"]:
+                        continue
+                    extra_intfs.append(intf_id)
+        payload["interfaces"].extend(extra_intfs)
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/disable/'
         response = requests.post(api_url, json=payload)

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -78,6 +78,10 @@ class TestE2EOfLLDP:
 
         # make sure the interfaces are actually receiving LLDP
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        for host in (h11, h12, h2, h3):
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
@@ -143,6 +147,10 @@ class TestE2EOfLLDP:
         time.sleep(5)
 
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        for host in (h11, h12, h2, h3):
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
@@ -195,6 +203,9 @@ class TestE2EOfLLDP:
         assert set(data["interfaces"]) == set(expected_interfaces)
 
         h11 = self.net.net.get('h11')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         time.sleep(10)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
@@ -225,6 +236,9 @@ class TestE2EOfLLDP:
         assert data["polling_time"] == default_polling_time
 
         h11 = self.net.net.get('h11')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         lldp_wait = 31
         time.sleep(lldp_wait)

--- a/tests/test_e2e_31_of_lldp.py
+++ b/tests/test_e2e_31_of_lldp.py
@@ -290,6 +290,8 @@ class TestE2EOfLLDP:
         # Deactivate the interface for deletion
         self.net.net.configLinkStatus('s1', 'h11', 'down')
 
+        time.sleep(5)
+
         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -662,10 +662,11 @@ class TestE2ESDNTrace:
                         "dl_vlan": 10
                     },
                     "actions": [
+                        {"action_type": "set_vlan", "vlan_id": 5 },
                         {
                             "action_type": "output",
                             "port": 2,
-                        }, {"action_type": "set_vlan", "vlan_id": 5 }
+                        },
                     ]
                 },
                 {

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -400,6 +400,9 @@ class TestE2ESDNTrace:
         cls.create_evc(100, "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:0a:1")
         cls.create_evc(101, "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:0a:1")
         cls.create_evc(102, "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:0a:1")
+
+        time.sleep(5)
+
         payload = [
                     {
                         "trace": {
@@ -952,7 +955,9 @@ class TestE2ESDNTrace:
         api_url = KYTOS_API + '/kytos/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
-        
+
+        time.sleep(5)
+
         payload = [
                     {
                         "trace": {
@@ -1045,6 +1050,9 @@ class TestE2ESDNTrace:
     def test_100_trace_circuit_vlan_range(cls):
         """Test traces for circuit with vlan range"""
         cls.create_evc([[12, 21]])
+
+        time.sleep(5)
+
         vlan1 = random.randrange(12, 16)
         vlan2 = random.randrange(16, 20)
         vlan3 = random.randrange(20, 22)

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -140,7 +140,7 @@ class TestE2ESDNTrace:
 
         assert expected == actual, f"Expected {expected}. Actual: {actual}"
 
-    def wait_sdntrace_result(self, trace_id, timeout=10):
+    def wait_sdntrace_result(self, trace_id, timeout=30):
         """Wait until sdntrace finishes."""
         wait_count = 0
         while wait_count < timeout:

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -48,9 +48,10 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 1,
-                    "description": "Second table for coloring",
+                    "description": "Second table for coloring and of_lldp",
                     "napps_table_groups": {
-                        "coloring": ["base"]
+                        "coloring": ["base"],
+                        "of_lldp": ["base"],
                     },
                     "table_miss_flow": {
                         "priority": 0,
@@ -62,9 +63,9 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 2,
-                    "description": "Third table for of_lldp",
+                    "description": "Third table for mef_eline evpl",
                     "napps_table_groups": {
-                        "of_lldp": ["base"]
+                        "mef_eline": ["evpl"],
                     },
                     "table_miss_flow": {
                         "priority": 0,
@@ -76,21 +77,7 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 3,
-                    "description": "Fourth table for mef_eline evpl",
-                    "napps_table_groups": {
-                        "mef_eline": ["evpl"],
-                    },
-                    "table_miss_flow": {
-                        "priority": 0,
-                        "instructions": [{
-                            "instruction_type": "goto_table",
-                            "table_id": 4
-                        }]
-                    },
-                },
-                {
-                    "table_id": 4,
-                    "description": "Fifth table for mef_eline epl",
+                    "description": "Fourth table for mef_eline epl",
                     "napps_table_groups": {
                         "mef_eline": ["epl"]
                     },

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -170,7 +170,7 @@ class TestE2EOfMultiTable:
         # of_lldp and coloring have same priority and
         # order is not deterministic
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 5, flows_s1
+        assert len(flows_s1) == 5, str(flows_s1)
         expected_flows_single_table = [
             # coloring: 2 flows
             (r"cookie=0xac00000000000001.*table=0.*dl_src=ee:ee:ee:.*actions=CONTROLLER:65535", 2),

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -1,4 +1,5 @@
 import time
+import re
 
 from tests.helpers import NetworkTest
 import requests
@@ -128,52 +129,36 @@ class TestE2EOfMultiTable:
         # Assert installed flows
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 9, flows_s1
-        assert "table=0" in flows_s1[0]
-        assert 'priority=0 actions=goto_table:1' in flows_s1[0]
-        assert "table=1" in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert "table=1" in flows_s1[2]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert "table=1" in flows_s1[3]
-        assert 'priority=0 actions=goto_table:2' in flows_s1[3]
-        assert "table=2" in flows_s1[4]
-        assert 'dl_type=0x88cc actions=CONTROLLER:65535' in flows_s1[4]
-        assert "table=2" in flows_s1[5]
-        assert 'priority=0 actions=goto_table:3' in flows_s1[5]
-        assert "table=3" in flows_s1[6]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[6]
-        assert "table=3" in flows_s1[7]
-        assert 'priority=0 actions=goto_table:4' in flows_s1[7]
-        assert "table=4" in flows_s1[8]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[8]
+        assert len(flows_s1) == 8, str(flows_s1)
+        expected_flows = [
+            # of_multi_table: 3 flows (tables 1, 2 and 3)
+            (r"cookie=0xad00000000000001.*table=0.*priority=0 actions=goto_table:1", 1),
+            (r"cookie=0xad00000000000001.*table=1.*priority=0 actions=goto_table:2", 1),
+            (r"cookie=0xad00000000000001.*table=2.*priority=0 actions=goto_table:3", 1),
+            # coloring: 2 flows (table 1)
+            (r"cookie=0xac00000000000001.*table=1.*dl_src=ee:ee:ee:.*actions=CONTROLLER:65535", 2),
+            # of_lldp: 1 flow (table 1)
+            (r"cookie=0xab00000000000001.*table=1.*dl_vlan=3799.*actions=CONTROLLER:65535", 1),
+            # mef_eline: 2 flows (table 2 and 3)
+            (r"cookie=0xaa.*table=2.*dl_vlan=100 actions=output:2", 1),
+            (r"cookie=0xaa.*table=3.*actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1", 1),
+        ]
+        for pattern, matches in expected_flows:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         self.net.start_controller(clean_config=False)
         self.net.wait_switches_connect()
         time.sleep(10)
 
         # Assert installed flows
-        s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 9, flows_s1
-        assert "table=0" in flows_s1[0]
-        assert 'priority=0 actions=goto_table:1' in flows_s1[0]
-        assert "table=1" in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert "table=1" in flows_s1[2]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert "table=1" in flows_s1[3]
-        assert 'priority=0 actions=goto_table:2' in flows_s1[3]
-        assert "table=2" in flows_s1[4]
-        assert 'dl_type=0x88cc actions=CONTROLLER:65535' in flows_s1[4]
-        assert "table=2" in flows_s1[5]
-        assert 'priority=0 actions=goto_table:3' in flows_s1[5]
-        assert "table=3" in flows_s1[6]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[6]
-        assert "table=3" in flows_s1[7]
-        assert 'priority=0 actions=goto_table:4' in flows_s1[7]
-        assert "table=4" in flows_s1[8]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[8]
+        assert len(flows_s1) == 8, str(flows_s1)
+        for pattern, matches in expected_flows:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         # Return to default pipeline
         # Disabled pipeline
@@ -184,16 +169,21 @@ class TestE2EOfMultiTable:
 
         # of_lldp and coloring have same priority and
         # order is not deterministic
-        s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
         assert len(flows_s1) == 5, flows_s1
-        for flow in flows_s1:
-            assert 'table=0' in flow
-        assert 'actions=CONTROLLER:65535' in flows_s1[0]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[3]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[4]
+        expected_flows_single_table = [
+            # coloring: 2 flows
+            (r"cookie=0xac00000000000001.*table=0.*dl_src=ee:ee:ee:.*actions=CONTROLLER:65535", 2),
+            # of_lldp: 1 flow (table 1)
+            (r"cookie=0xab00000000000001.*table=0.*dl_vlan=3799.*actions=CONTROLLER:65535", 1),
+            # mef_eline: 2 flows
+            (r"cookie=0xaa.*table=0.*dl_vlan=100 actions=output:2", 1),
+            (r"cookie=0xaa.*table=0.*actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1", 1),
+        ]
+        for pattern, matches in expected_flows_single_table:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         # Delete disabled pipeline
         api_url = f"{KYTOS_API}{OF_MULTI_TABLE_API}/{data['id']}"

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -1,5 +1,6 @@
 import time
 import json
+import pytest
 
 from tests.helpers import NetworkTest
 import requests
@@ -117,11 +118,29 @@ class TestE2EKytosStats:
         # install a flow
         cookie = 5
         payload = {
-            "flows": [{
-                "cookie": cookie,
-                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
-                'actions': [{'action_type': 'output', 'port': 2}]
-            }]
+            "flows": [
+                {
+                    "table_id": 0,
+                    "cookie": 1000 + cookie,
+                    "match": {"in_port": 1, 'dl_type': 0x86dd},
+                    "instructions": [
+                        {
+                            "instruction_type": "goto_table",
+                            "table_id": 1,
+                        },
+                    ],
+                },
+                {
+                    "table_id": 1,
+                    "cookie": cookie,
+                    "match": {
+                        "in_port": 1,
+                        'dl_dst': '33:33:00:00:00:02',
+                        'dl_type': 0x86dd,
+                    },
+                    'actions': [{'action_type': 'output', 'port': 2}]
+                },
+            ]
         }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
@@ -153,6 +172,8 @@ class TestE2EKytosStats:
                 assert packet_counter >= n, str(flow)
                 packet_per_second = packet_counter/flow['duration_sec']
                 break
+        else:
+            pytest.fail(f"Flow not found: {data_flow}")
         
         api_url = KYTOS_STATS + f'/packet_count/{flow_id}' 
         response = requests.get(api_url)
@@ -169,11 +190,29 @@ class TestE2EKytosStats:
         # install a flow
         cookie = 5
         payload = {
-            "flows": [{
-                "cookie": cookie,
-                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
-                'actions': [{'action_type': 'output', 'port': 2}]
-            }]
+            "flows": [
+                {
+                    "table_id": 0,
+                    "cookie": 1000 + cookie,
+                    "match": {"in_port": 1, 'dl_type': 0x86dd},
+                    "instructions": [
+                        {
+                            "instruction_type": "goto_table",
+                            "table_id": 1,
+                        },
+                    ],
+                },
+                {
+                    "table_id": 1,
+                    "cookie": cookie,
+                    "match": {
+                        "in_port": 1,
+                        'dl_dst': '33:33:00:00:00:02',
+                        'dl_type': 0x86dd,
+                    },
+                    'actions': [{'action_type': 'output', 'port': 2}]
+                },
+            ]
         }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
@@ -205,6 +244,8 @@ class TestE2EKytosStats:
                 assert bytes_counter >= n*1500, str(flow)
                 bits_per_second = 8*bytes_counter/flow['duration_sec']
                 break
+        else:
+            pytest.fail(f"Flow not found: {data_flow}")
         
         api_url = KYTOS_STATS + f'/bytes_count/{flow_id}' 
         response = requests.get(api_url)

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -317,7 +317,7 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
-        time.sleep(10)
+        time.sleep(15)
 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
@@ -356,7 +356,7 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
-        time.sleep(10)
+        time.sleep(15)
 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text

--- a/tests/test_e2e_95_telemtry_int.py
+++ b/tests/test_e2e_95_telemtry_int.py
@@ -27,8 +27,11 @@ def parse_int_collector(data):
 
 
 @pytest.mark.skipif(
-    os.environ.get("SWITCH_CLASS") != "NoviSwitch"
-    or os.environ.get("NOVIVERSION") != "NW570.6.1",
+    os.environ.get("SWITCH_CLASS") not in ("NoviSwitch", "P4OfSwitch")
+    or (
+        os.environ.get("SWITCH_CLASS") == "NoviSwitch"
+        and os.environ.get("NOVIVERSION") != "NW570.6.1"
+    ),
     reason="NoviSwitch does not support interface removal",
 )
 class TestE2ETelemtryINT:
@@ -152,16 +155,28 @@ class TestE2ETelemtryINT:
         self.config_host_ip_vlan(h3, "10.1.98.3", 198)
 
         # enable INT Collector on switches
-        s1.novi_cmd(
-            "set config int monitor portno 3 ethdst 00:00:00:00:02:01 ethsrc 00:00:00:aa:aa:01 "
-            "ipv4src 10.255.255.1 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
-        )
-        s1.novi_cmd("set config int maxhopcount 10")
-        s6.novi_cmd(
-            "set config int monitor portno 3 ethdst 00:00:00:00:02:03 ethsrc 00:00:00:aa:aa:06 "
-            "ipv4src 10.255.255.6 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
-        )
-        s6.novi_cmd("set config int maxhopcount 10")
+        if os.environ.get("SWITCH_CLASS") == "NoviSwitch":
+            s1.novi_cmd(
+                "set config int monitor portno 3 ethdst 00:00:00:00:02:01 ethsrc 00:00:00:aa:aa:01 "
+                "ipv4src 10.255.255.1 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
+            )
+            s1.novi_cmd("set config int maxhopcount 10")
+            s6.novi_cmd(
+                "set config int monitor portno 3 ethdst 00:00:00:00:02:03 ethsrc 00:00:00:aa:aa:06 "
+                "ipv4src 10.255.255.6 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
+            )
+            s6.novi_cmd("set config int maxhopcount 10")
+        elif os.environ.get("SWITCH_CLASS") == "P4OfSwitch":
+            s1.cmd(
+                "p4ofagent set config int --of_port_no 3 --src_mac 00:00:00:aa:aa:01 --dst_mac 00:00:00:00:02:01 "
+                "--src_ip 10.255.255.1 --dst_ip 10.255.255.254 --dst_udp 5900 --max_pkt_len 320"
+            )
+            s6.cmd(
+                "p4ofagent set config int --of_port_no 3 --src_mac 00:00:00:aa:aa:06 --dst_mac 00:00:00:00:02:03 "
+                "--src_ip 10.255.255.6 --dst_ip 10.255.255.254 --dst_udp 5900 --max_pkt_len 320"
+            )
+        else:
+            pytest.fail("Unsupported SWITCH_CLASS. Supported values: NoviSwitch, P4OfSwitch")
 
         # start int collector
         h2.cmd(
@@ -255,8 +270,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:7 -- s6:7
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "down")
+        self.net.net.wait_kytos_links("s1", "s6", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:5", "00:00:00:00:00:00:00:05:5"],
@@ -317,8 +333,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:5 -- s5:5
         #####################################################
         self.net.net.configLinkStatus("s1", "s5", "down")
+        self.net.net.wait_kytos_links("s1", "s5", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -380,8 +397,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:5 -- s6:5
         #####################################################
         self.net.net.configLinkStatus("s2", "s6", "down")
+        self.net.net.wait_kytos_links("s2", "s6", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -456,8 +474,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:8 -- s6:8
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=8, port2=8)
+        self.net.net.wait_kytos_links("s5", "s6", port1=8, port2=8, status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -540,8 +559,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:4 -- s3:4
         #####################################################
         self.net.net.configLinkStatus("s2", "s3", "down")
+        self.net.net.wait_kytos_links("s2", "s3", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -604,8 +624,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:9 -- s6:9
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=9, port2=9)
+        self.net.net.wait_kytos_links("s2", "s3", port1=9, port2=9, status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         self.validate_evc_paths(evc_id, [], [])
 
@@ -622,8 +643,9 @@ class TestE2ETelemtryINT:
         ## simulate link UP on s1 -- s6 to check if the EVC will recover
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "up")
+        self.net.net.wait_kytos_links("s1", "s6", status="UP")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:7", "00:00:00:00:00:00:00:06:7"],

--- a/tests/test_e2e_95_telemtry_int.py
+++ b/tests/test_e2e_95_telemtry_int.py
@@ -54,7 +54,7 @@ class TestE2ETelemtryINT:
     def setup_class(cls):
         """Called once before all test methods within a class are run."""
         cls.net = NetworkTest(CONTROLLER, topo_name="amlight_intlab")
-        cls.net.start()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_95_telemtry_int.py
+++ b/tests/test_e2e_95_telemtry_int.py
@@ -1,6 +1,7 @@
 """End-to-end tests for telemetry_int Napp."""
 
 import os
+import re
 import time
 from pathlib import Path
 
@@ -116,9 +117,8 @@ class TestE2ETelemtryINT:
         expected_counts: list[tuples] (switch_obj, expected_int)
         """
         for switch, count in expected_counts:
-            flows = switch.dpctl(
-                "dump-flows", f"cookie=0xa0{evc_id}/0xf0ffffffffffffff"
-            ).splitlines()
+            flows = switch.dpctl("dump-flows").splitlines()
+            flows = [flow for flow in flows if re.search(rf"cookie=0xa.{evc_id}", flow)]
             assert len(flows) == count, f"Wrong flows length for {switch}: {flows}"
 
     def validate_traffic(self, src, dst):
@@ -270,7 +270,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:7 -- s6:7
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "down")
-        self.net.net.wait_kytos_links("s1", "s6", status="DOWN")
+        self.net.wait_kytos_links("s1", "s6", status="DOWN")
 
         time.sleep(5)
 
@@ -333,7 +333,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:5 -- s5:5
         #####################################################
         self.net.net.configLinkStatus("s1", "s5", "down")
-        self.net.net.wait_kytos_links("s1", "s5", status="DOWN")
+        self.net.wait_kytos_links("s1", "s5", status="DOWN")
 
         time.sleep(5)
 
@@ -397,7 +397,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:5 -- s6:5
         #####################################################
         self.net.net.configLinkStatus("s2", "s6", "down")
-        self.net.net.wait_kytos_links("s2", "s6", status="DOWN")
+        self.net.wait_kytos_links("s2", "s6", status="DOWN")
 
         time.sleep(5)
 
@@ -474,7 +474,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:8 -- s6:8
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=8, port2=8)
-        self.net.net.wait_kytos_links("s5", "s6", port1=8, port2=8, status="DOWN")
+        self.net.wait_kytos_links("s5", "s6", port1=8, port2=8, status="DOWN")
 
         time.sleep(5)
 
@@ -559,7 +559,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:4 -- s3:4
         #####################################################
         self.net.net.configLinkStatus("s2", "s3", "down")
-        self.net.net.wait_kytos_links("s2", "s3", status="DOWN")
+        self.net.wait_kytos_links("s2", "s3", status="DOWN")
 
         time.sleep(5)
 
@@ -624,7 +624,7 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:9 -- s6:9
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=9, port2=9)
-        self.net.net.wait_kytos_links("s2", "s3", port1=9, port2=9, status="DOWN")
+        self.net.wait_kytos_links("s2", "s3", port1=9, port2=9, status="DOWN")
 
         time.sleep(5)
 
@@ -643,7 +643,7 @@ class TestE2ETelemtryINT:
         ## simulate link UP on s1 -- s6 to check if the EVC will recover
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "up")
-        self.net.net.wait_kytos_links("s1", "s6", status="UP")
+        self.net.wait_kytos_links("s1", "s6", status="UP")
 
         time.sleep(5)
 


### PR DESCRIPTION
Closes #issue_number

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

I'm running the end-to-end tests with Kytos based on the P4OfSwitch available on Docker image `amlight/p4ofswitch:latest` (Github repo to be published soon) and Mininet with Docker support (Docker-in-Docker exec methodology) based on this forked version (https://github.com/italovalcy/mininet/releases/tag/2.3.2).

I'm using the following setup:

```
docker run -d --name mongo2 mongo:7.0

docker exec -it mongo2 mongosh --eval 'db.getSiblingDB("k2").createUser({user: "k2", pwd: "k2", roles: [ { role: "dbAdmin", db: "k2" } ]})'

docker run -d --name kafka2 --hostname kafka2 -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka2:9092  apache/kafka:4.0.0

docker run -d --name k2 --privileged -v /home/italo/docker:/var/lib/docker -v /lib/modules:/lib/modules --link mongo2 --link kafka2 -e SWITCH_CLASS=P4OfSwitch -e MONGO_DBNAME=k2 -e MONGO_USERNAME=k2 -e MONGO_PASSWORD=k2 -e MONGO_HOST_SEEDS=mongo2:27017  -e KAFKA_HOST_ADDR=kafka2:9092 --pull always --init amlight/kytos:latest /usr/bin/tail -f /dev/null

docker exec -it k2 bash

# all steps below are executed inside the k2 docker container:

apt-get update

apt-get install -y --no-install-recommends --no-install-suggests gnupg

curl -LO https://github.com/italovalcy/mininet/releases/download/2.3.2/mininet_2.3.2-1--debian12_amd64.deb

apt-get install -y ./mininet_2.3.2-1--debian12_amd64.deb

install -m 0755 -d /etc/apt/keyrings  && curl -fsSL https://download.docker.com/linux/debian/gpg     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg  && chmod a+r /etc/apt/keyrings/docker.gpg  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable"     | tee /etc/apt/sources.list.d/docker.list

apt-get update && apt-get install --no-install-recommends --no-install-suggests -y     docker-ce     docker-ce-cli     containerd.io     docker-buildx-plugin     docker-compose-plugin

setsid dockerd > /var/log/dockerd.log 2>&1 &

until docker info > /dev/null 2>&1; do sleep 1; done

docker pull amlight/p4ofswitch:latest

git clone https://github.com/kytos-ng/kytos-end-to-end-tests

cd kytos-end-to-end-tests/

git checkout feat/p4ofswitch

tmux new-sess -d -s e2e-tests bash -c 'env TESTS="tests/" RERUNS=2 ./kytos-init.sh 2>&1 | tee e2e-results-1.log; bash'
```

### End-to-End Tests


```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: anyio-4.3.0, rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

------------------------------- start/stop times -------------------------------
===== 277 passed, 11 skipped, 7 xfailed, 7 xpassed in 20506.84s (5:41:46) ======
```

Another exec (the one below has a RERUN on `tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_040_replace_action_flow` which was fixed by commit 5e03037a668cf96209583b97f2b2d766c1012fb6):

```
+ '[' -z '' ']'
+ '[' -z '' ']'
+ echo 'There is no NAPPS_PATH specified. Default will be used.'
There is no NAPPS_PATH specified. Default will be used.
+ NAPPS_PATH=
+ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+ sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
+ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ kytosd --help
+ sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
+ grep -q aiokafka /etc/kytos/logging.ini
+ test -z tests/
+ test -z 2
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 scripts/setup_kafka.py
Starting setup_kafka.py...
Attempting to create an admin client at ['kafka1:9092']...
Admin client was successful! Attempting to validate cluster...
Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'kafka1', 'port': 9092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 1}
Cluster was successfully validated! Attempting to create topic 'event_logs'...
Topic 'event_logs' was created! Attempting to close the admin client...
Kafka admin client closed.
+ date
Wed Apr 29 01:47:31 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: anyio-4.3.0, rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py .............R...............          [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

------------------------------- start/stop times -------------------------------
rerun: 0
tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_040_replace_action_flow: 2026-04-29,04:55:23.038924 - 2026-04-29,04:55:51.646347
self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7f742b7587d0>

    def test_040_replace_action_flow(self):
>       self.replace_action_flow()

tests/test_e2e_20_flow_manager.py:886:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7f742b7587d0>
restart_kytos = False

    def replace_action_flow(self, restart_kytos=False):

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        requests.post(api_url, data=json.dumps(payload),
                      headers={'Content-type': 'application/json'})

        # wait for the flow to be installed
        time.sleep(10)

        # Verify the flow
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
        assert 'in_port=1' in flows_s1

        # Modify the actions and verify its modification
        s1.dpctl('mod-flows', 'actions=output:3')
        flows_s1 = s1.dpctl('dump-flows')
        assert 'actions=output:2' not in flows_s1
        assert 'actions=output:3' in flows_s1

        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller(enable_all=True)
            self.net.wait_switches_connect()
        else:
            self.net.reconnect_switches()

        time.sleep(10)

        # Check that the flow keeps the original setting
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
>       assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
E       AssertionError:  cookie=0xab00000000000001, duration=11s, table=0, n_packets=3, n_bytes=192, priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
E          cookie=0xac00000000000001, duration=11s, table=0, n_packets=0, n_bytes=0, priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
E          cookie=0x0, duration=11s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port=1 actions=output:2
E
E       assert 3 == (3 + 1)
E        +  where 3 = len([' cookie=0xab00000000000001, duration=11s, table=0, n_packets=3, n_bytes=192, priority=50000,dl_vlan=3799,dl_type=0x8...ion=11s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port=1 actions=output:2'])
E        +    where [' cookie=0xab00000000000001, duration=11s, table=0, n_packets=3, n_bytes=192, priority=50000,dl_vlan=3799,dl_type=0x8...ion=11s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port=1 actions=output:2'] = <built-in method splitlines of str object at 0x7f7429d81c50>()
E        +      where <built-in method splitlines of str object at 0x7f7429d81c50> = ' cookie=0xab00000000000001, duration=11s, table=0, n_packets=3, n_bytes=192, priority=50000,dl_vlan=3799,dl_type=0x88...=11s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port=1 actions=output:2\r\n'.splitlines

tests/test_e2e_20_flow_manager.py:881: AssertionError
=========================== rerun test summary info ============================
RERUN tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_040_replace_action_flow
= 277 passed, 11 skipped, 7 xfailed, 7 xpassed, 1 rerun in 21247.58s (5:54:07) =
```