### PR TITLE
Using multiple tables to deal with restrictions on NoviSwitch and P4OfSwitch

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -1,5 +1,6 @@
 import time
 import json
+import pytest
 
 from tests.helpers import NetworkTest
 import requests
@@ -117,11 +118,29 @@ class TestE2EKytosStats:
         # install a flow
         cookie = 5
         payload = {
-            "flows": [{
-                "cookie": cookie,
-                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
-                'actions': [{'action_type': 'output', 'port': 2}]
-            }]
+            "flows": [
+                {
+                    "table_id": 0,
+                    "cookie": 1000 + cookie,
+                    "match": {"in_port": 1, 'dl_type': 0x86dd},
+                    "instructions": [
+                        {
+                            "instruction_type": "goto_table",
+                            "table_id": 1,
+                        },
+                    ],
+                },
+                {
+                    "table_id": 1,
+                    "cookie": cookie,
+                    "match": {
+                        "in_port": 1,
+                        'dl_dst': '33:33:00:00:00:02',
+                        'dl_type': 0x86dd,
+                    },
+                    'actions': [{'action_type': 'output', 'port': 2}]
+                },
+            ]
         }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
@@ -153,6 +172,8 @@ class TestE2EKytosStats:
                 assert packet_counter >= n, str(flow)
                 packet_per_second = packet_counter/flow['duration_sec']
                 break
+        else:
+            pytest.fail(f"Flow not found: {data_flow}")
         
         api_url = KYTOS_STATS + f'/packet_count/{flow_id}' 
         response = requests.get(api_url)
@@ -169,11 +190,29 @@ class TestE2EKytosStats:
         # install a flow
         cookie = 5
         payload = {
-            "flows": [{
-                "cookie": cookie,
-                "match": {"in_port": 1, 'dl_dst': '33:33:00:00:00:02', 'dl_type': 0x86dd},
-                'actions': [{'action_type': 'output', 'port': 2}]
-            }]
+            "flows": [
+                {
+                    "table_id": 0,
+                    "cookie": 1000 + cookie,
+                    "match": {"in_port": 1, 'dl_type': 0x86dd},
+                    "instructions": [
+                        {
+                            "instruction_type": "goto_table",
+                            "table_id": 1,
+                        },
+                    ],
+                },
+                {
+                    "table_id": 1,
+                    "cookie": cookie,
+                    "match": {
+                        "in_port": 1,
+                        'dl_dst': '33:33:00:00:00:02',
+                        'dl_type': 0x86dd,
+                    },
+                    'actions': [{'action_type': 'output', 'port': 2}]
+                },
+            ]
         }
 
         api_url_flow_manager = KYTOS_API + f'/kytos/flow_manager/v2/flows/{sw}'
@@ -205,6 +244,8 @@ class TestE2EKytosStats:
                 assert bytes_counter >= n*1500, str(flow)
                 bits_per_second = 8*bytes_counter/flow['duration_sec']
                 break
+        else:
+            pytest.fail(f"Flow not found: {data_flow}")
         
         api_url = KYTOS_STATS + f'/bytes_count/{flow_id}' 
         response = requests.get(api_url)
@@ -276,7 +317,7 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
-        time.sleep(10)
+        time.sleep(15)
 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
@@ -315,7 +356,7 @@ class TestE2EKytosStats:
         data_flow = response.json()
         assert 'FlowMod Messages Sent' in data_flow['response']
 
-        time.sleep(10)
+        time.sleep(15)
 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text


### PR DESCRIPTION
Related to #432

### Summary

- This PR applies a slightly change to Kytos Stats tests to use multiple tables to create the test validation. Before we were using only Table 0 to create a flow matching on Ethernet Destination Address. While this works just fine for OpenVSwitch, when using P4OFSwitch or NoviSwitch, this will create an issue because matching on `dl_dst` is only supported on Table 1. Thus, this PR will basically change the approach to create a goto flow on table 0 and then create the actual flow on Table 1.
- Additionally, I changed the time to allow more time for the flows to be installed and also stats to be requested and received (on P4OFSwitch, sometimes it takes longer for BfRuntime to provide the flow stats).

### Local Tests

N/A

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```