### PR TITLE
Adjusting the tables to deal with restrictions on NoviSwitch and P4OfSwitch

### DIFF
--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -1,4 +1,5 @@
 import time
+import re
 
 from tests.helpers import NetworkTest
 import requests
@@ -48,9 +49,10 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 1,
-                    "description": "Second table for coloring",
+                    "description": "Second table for coloring and of_lldp",
                     "napps_table_groups": {
-                        "coloring": ["base"]
+                        "coloring": ["base"],
+                        "of_lldp": ["base"],
                     },
                     "table_miss_flow": {
                         "priority": 0,
@@ -62,9 +64,9 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 2,
-                    "description": "Third table for of_lldp",
+                    "description": "Third table for mef_eline evpl",
                     "napps_table_groups": {
-                        "of_lldp": ["base"]
+                        "mef_eline": ["evpl"],
                     },
                     "table_miss_flow": {
                         "priority": 0,
@@ -76,21 +78,7 @@ class TestE2EOfMultiTable:
                 },
                 {
                     "table_id": 3,
-                    "description": "Fourth table for mef_eline evpl",
-                    "napps_table_groups": {
-                        "mef_eline": ["evpl"],
-                    },
-                    "table_miss_flow": {
-                        "priority": 0,
-                        "instructions": [{
-                            "instruction_type": "goto_table",
-                            "table_id": 4
-                        }]
-                    },
-                },
-                {
-                    "table_id": 4,
-                    "description": "Fifth table for mef_eline epl",
+                    "description": "Fourth table for mef_eline epl",
                     "napps_table_groups": {
                         "mef_eline": ["epl"]
                     },
@@ -141,52 +129,36 @@ class TestE2EOfMultiTable:
         # Assert installed flows
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 9, flows_s1
-        assert "table=0" in flows_s1[0]
-        assert 'priority=0 actions=goto_table:1' in flows_s1[0]
-        assert "table=1" in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert "table=1" in flows_s1[2]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert "table=1" in flows_s1[3]
-        assert 'priority=0 actions=goto_table:2' in flows_s1[3]
-        assert "table=2" in flows_s1[4]
-        assert 'dl_type=0x88cc actions=CONTROLLER:65535' in flows_s1[4]
-        assert "table=2" in flows_s1[5]
-        assert 'priority=0 actions=goto_table:3' in flows_s1[5]
-        assert "table=3" in flows_s1[6]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[6]
-        assert "table=3" in flows_s1[7]
-        assert 'priority=0 actions=goto_table:4' in flows_s1[7]
-        assert "table=4" in flows_s1[8]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[8]
+        assert len(flows_s1) == 8, str(flows_s1)
+        expected_flows = [
+            # of_multi_table: 3 flows (tables 1, 2 and 3)
+            (r"cookie=0xad00000000000001.*table=0.*priority=0 actions=goto_table:1", 1),
+            (r"cookie=0xad00000000000001.*table=1.*priority=0 actions=goto_table:2", 1),
+            (r"cookie=0xad00000000000001.*table=2.*priority=0 actions=goto_table:3", 1),
+            # coloring: 2 flows (table 1)
+            (r"cookie=0xac00000000000001.*table=1.*dl_src=ee:ee:ee:.*actions=CONTROLLER:65535", 2),
+            # of_lldp: 1 flow (table 1)
+            (r"cookie=0xab00000000000001.*table=1.*dl_vlan=3799.*actions=CONTROLLER:65535", 1),
+            # mef_eline: 2 flows (table 2 and 3)
+            (r"cookie=0xaa.*table=2.*dl_vlan=100 actions=output:2", 1),
+            (r"cookie=0xaa.*table=3.*actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1", 1),
+        ]
+        for pattern, matches in expected_flows:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         self.net.start_controller(clean_config=False)
         self.net.wait_switches_connect()
         time.sleep(10)
 
         # Assert installed flows
-        s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 9, flows_s1
-        assert "table=0" in flows_s1[0]
-        assert 'priority=0 actions=goto_table:1' in flows_s1[0]
-        assert "table=1" in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert "table=1" in flows_s1[2]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert "table=1" in flows_s1[3]
-        assert 'priority=0 actions=goto_table:2' in flows_s1[3]
-        assert "table=2" in flows_s1[4]
-        assert 'dl_type=0x88cc actions=CONTROLLER:65535' in flows_s1[4]
-        assert "table=2" in flows_s1[5]
-        assert 'priority=0 actions=goto_table:3' in flows_s1[5]
-        assert "table=3" in flows_s1[6]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[6]
-        assert "table=3" in flows_s1[7]
-        assert 'priority=0 actions=goto_table:4' in flows_s1[7]
-        assert "table=4" in flows_s1[8]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[8]
+        assert len(flows_s1) == 8, str(flows_s1)
+        for pattern, matches in expected_flows:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         # Return to default pipeline
         # Disabled pipeline
@@ -197,16 +169,21 @@ class TestE2EOfMultiTable:
 
         # of_lldp and coloring have same priority and
         # order is not deterministic
-        s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows').splitlines()
-        assert len(flows_s1) == 5, flows_s1
-        for flow in flows_s1:
-            assert 'table=0' in flow
-        assert 'actions=CONTROLLER:65535' in flows_s1[0]
-        assert 'actions=CONTROLLER:65535' in flows_s1[1]
-        assert 'actions=CONTROLLER:65535' in flows_s1[2]
-        assert 'dl_vlan=100 actions=output:2' in flows_s1[3]
-        assert 'actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1' in flows_s1[4]
+        assert len(flows_s1) == 5, str(flows_s1)
+        expected_flows_single_table = [
+            # coloring: 2 flows
+            (r"cookie=0xac00000000000001.*table=0.*dl_src=ee:ee:ee:.*actions=CONTROLLER:65535", 2),
+            # of_lldp: 1 flow (table 1)
+            (r"cookie=0xab00000000000001.*table=0.*dl_vlan=3799.*actions=CONTROLLER:65535", 1),
+            # mef_eline: 2 flows
+            (r"cookie=0xaa.*table=0.*dl_vlan=100 actions=output:2", 1),
+            (r"cookie=0xaa.*table=0.*actions=push_vlan:0x8100,set_field:4196->vlan_vid,output:1", 1),
+        ]
+        for pattern, matches in expected_flows_single_table:
+            assert sum(
+                len(re.findall(pattern, flow)) for flow in flows_s1
+            ) == matches, f"{matches=} {pattern=} {flows_s1=}"
 
         # Delete disabled pipeline
         api_url = f"{KYTOS_API}{OF_MULTI_TABLE_API}/{data['id']}"


### PR DESCRIPTION
Related to #432

### Summary

- This PR applies a slightly change to Kytos Multi Table tests to use less number of tables to match with restrictions from NoviSwitch and P4OfSwitch. They both were pre-configured to support 4 tables only, while the original Multi Table tests assumed 5 tables. With the proposed solution, we are using table 0 for LLDP and Coloring.
- Additionally, once P4OfAgent does not support filters on FlowStats  Multipart Request, I changed the approach to use regex to filter the output.

### Local Tests

N/A

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```