### PR TITLE
Fix waiting time and remove unwanted IPv6 SLAAC frames from statistics

### DIFF
--- a/tests/noviswitch.py
+++ b/tests/noviswitch.py
@@ -623,5 +623,10 @@ class NoviSwitch(Switch):
             cmd = "set config port portno %d portdown %s" % (portno, portdown)
             self.novi_cmd(cmd)
 
+    def get_all_of_ports(self):
+        """Get all OpenFlow port numbers."""
+        ports = self.dpctl("dump-ports --no-names")
+        return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))
+
 
 addCleanupCallback(NoviSwitch.batch_cleanup)

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -56,18 +56,32 @@ class TestE2EOfLLDP:
         # s1 lo:  s1-eth1:h11-eth0 s1-eth2:h12-eth0 s1-eth3:s2-eth2 s1-eth4:s3-eth3
         # s2 lo:  s2-eth1:h2-eth0 s2-eth2:s1-eth3 s2-eth3:s3-eth2
         # s3 lo:  s3-eth1:h3-eth0 s3-eth2:s2-eth3 s3-eth3:s1-eth4
-        expected_interfaces = [
+        expected_interfaces = set([
                 "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:01:3",
                 "00:00:00:00:00:00:00:01:4", "00:00:00:00:00:00:00:01:4294967294",
                 "00:00:00:00:00:00:00:02:1", "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
                 "00:00:00:00:00:00:00:02:4294967294",
                 "00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3",
                 "00:00:00:00:00:00:00:03:4294967294"
-        ]
+        ])
+        # some switches have more interfaces than the ones configured by
+        # mininet (ex: Noviflow switches, P4OfSwitch)
+        for sw_name in ["s1", "s2", "s3"]:
+            sw = self.net.net.get(sw_name)
+            if hasattr(sw, "get_all_of_ports"):
+                ports = sw.get_all_of_ports()
+                dpid = ":".join([sw.dpid[i:i+2] for i in range(0, 16, 2)])
+                intf_ids = [f"{dpid}:{port}" for port in ports]
+                expected_interfaces.update(intf_ids)
+
         assert set(data["interfaces"]) == set(expected_interfaces)
 
         # make sure the interfaces are actually receiving LLDP
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        for host in (h11, h12, h2, h3):
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
@@ -103,6 +117,22 @@ class TestE2EOfLLDP:
                 "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
                 "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3"
         ]
+        # some switches have more interfaces than the ones configured by
+        # mininet (ex: Noviflow switches, P4OfSwitch)
+        extra_intfs = []
+        for sw_name in ["s1", "s2", "s3"]:
+            sw = self.net.net.get(sw_name)
+            if hasattr(sw, "get_all_of_ports"):
+                ports = sw.get_all_of_ports()
+                dpid = ":".join([sw.dpid[i:i+2] for i in range(0, 16, 2)])
+                for port in ports:
+                    intf_id = f"{dpid}:{port}"
+                    if intf_id in expected_interfaces:
+                        continue
+                    if intf_id in payload["interfaces"]:
+                        continue
+                    extra_intfs.append(intf_id)
+        payload["interfaces"].extend(extra_intfs)
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/disable/'
         response = requests.post(api_url, json=payload)
@@ -113,21 +143,28 @@ class TestE2EOfLLDP:
         data = response.json()
         assert set(data["interfaces"]) == set(expected_interfaces)
 
+        # wait LLDP message that were being sent before disabling
+        time.sleep(5)
+
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        for host in (h11, h12, h2, h3):
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
         rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
-        time.sleep(10)
+        time.sleep(15)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
         rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
 
-        assert rx_stats_h11_2 == rx_stats_h11 \
-            and rx_stats_h12_2 == rx_stats_h12 \
-            and rx_stats_h2_2 == rx_stats_h2 \
-            and rx_stats_h3_2 == rx_stats_h3
+        assert rx_stats_h11_2 == rx_stats_h11
+        assert rx_stats_h12_2 == rx_stats_h12
+        assert rx_stats_h2_2 == rx_stats_h2
+        assert rx_stats_h3_2 == rx_stats_h3
 
         # restart kytos and check if lldp remains disabled
         self.net.start_controller(clean_config=False, enable_all=False)
@@ -166,6 +203,9 @@ class TestE2EOfLLDP:
         assert set(data["interfaces"]) == set(expected_interfaces)
 
         h11 = self.net.net.get('h11')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         time.sleep(10)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
@@ -196,6 +236,9 @@ class TestE2EOfLLDP:
         assert data["polling_time"] == default_polling_time
 
         h11 = self.net.net.get('h11')
+        # disable ipv6 router solicitation to avoid interfere with LLDP stats
+        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         lldp_wait = 31
         time.sleep(lldp_wait)
@@ -222,4 +265,4 @@ class TestE2EOfLLDP:
         delta_pps_2 = rx_stats_h11_2 - rx_stats_h11
 
         # the delta pps now should be around 30, because the interval is every 1s
-        assert delta_pps_2 > delta_pps + 15
+        assert delta_pps_2 > 2*delta_pps

--- a/tests/test_e2e_31_of_lldp.py
+++ b/tests/test_e2e_31_of_lldp.py
@@ -290,6 +290,8 @@ class TestE2EOfLLDP:
         # Deactivate the interface for deletion
         self.net.net.configLinkStatus('s1', 'h11', 'down')
 
+        time.sleep(5)
+
         api_url = f'{KYTOS_API}/topology/v3/interfaces/{intf_id}'
         response = requests.delete(api_url)
         assert response.status_code == 200, response.text


### PR DESCRIPTION
Related to #432

### Summary

- Fix waiting timers to allow proper time for the Link Status change to be propagated before deleting the interface (this would impact `tests/test_e2e_31_of_lldp.py::test_010_liveness_intf_deletion`)
- also adding time.sleep after disabling the LLDP, to allow a few seconds for previous running LLDP sender to finish before start to account for number of LLDP packets sent
- Disabling IPv6 SLAAC (Stateless Address Auto Configuration), which sends IPv6 Router Solicitation at the begin and those messages ends up messing with the expected statistics for LLDP:
```
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
```
- Separate assertions on the number of packets expected, to better understand the failures.
- Changing the expected "delta pps" from "+ 15" packets to the double of previous counter. This makes more sense because we decreased the LLDP interval from 3s to 1s, so the number of packets should at least double (theoretically it will triple, but considering a slower Switch class, the pacing will be proportional to values with 3s interface, but with a smaller interface you expects the messages to be double).
- Adding a `get_all_of_ports()` function to automatically adjust the expected interfaces by default when getting LLDP APIs. When running with Switch class like Noviflow or P4OfSwitch the number of interfaces by default is much higher. With the `get_all_of_ports()` function, the specific Switch Class can feed the LLDP tests with those additional interfaces, for proper validation.

### Local Tests

N/A

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```