### PR TITLE
fix flake tests on mef_eline and flow_manager by adjusting timers and action order

### DIFF
--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -417,6 +417,8 @@ class TestE2EMefEline:
         response = requests.patch(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
+        time.sleep(5)
+
         # Check for VLAN 999
         api_url = f'{KYTOS_API}/topology/v3/interfaces/tag_ranges'
         response = requests.get(api_url)

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -241,6 +241,8 @@ class TestE2EMefEline:
         assert response.status_code == 201, response.text
         assert 'circuit_id' in response.json()
 
+        time.sleep(5)
+
         # Verify if EVC tag has been allocated
         topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
         response = requests.get(topo_url)
@@ -345,6 +347,8 @@ class TestE2EMefEline:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
 
+        time.sleep(5)
+
         intf_id = '00:00:00:00:00:00:00:01:1'
         api_url = KYTOS_API + f'/topology/v3/interfaces/{intf_id}/tag_ranges'
         response = requests.get(api_url)
@@ -444,6 +448,8 @@ class TestE2EMefEline:
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201, response.text
         circuit_id = response.json()["circuit_id"]
+
+        time.sleep(5)
 
         expected = [[1, 9], [16, 3798], [3800, 4094]]
         intf_id = '00:00:00:00:00:00:00:01:1'

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -1,5 +1,6 @@
 import json
 import time
+import re
 
 import requests
 
@@ -77,7 +78,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that the flow that was sent is on /v2/stored_flows
         dpid = "00:00:00:00:00:00:00:01"
@@ -138,7 +142,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         sw = self.net.net.get("s1")
         flows_sw = sw.dpctl("dump-flows")
@@ -255,7 +262,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
@@ -350,7 +360,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}&cookie_range=1&cookie_range=3'
         response = requests.get(stored_flows)
@@ -405,7 +418,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -457,7 +473,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that flows are soft deleted on /v2/stored_flows
         response = requests.get(
@@ -481,13 +500,13 @@ class TestE2EFlowManager:
         for i in range(1, 4):
             dpid = f"00:00:00:00:00:00:00:0{i}"
             assert dpid in data
-            assert len(data[dpid]["flows"]) == BASIC_FLOWS, data[dpid]
+            assert len(data[dpid]["flows"]) == BASIC_FLOWS, f"dpid={dpid} data={data[dpid]}"
 
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
             flows_sw = sw.dpctl('dump-flows')
             assert len(flows_sw.splitlines()) == BASIC_FLOWS, flows_sw
-            assert 'actions=output:2' not in flows_sw
+            assert 'actions=output:2' not in flows_sw, flows_sw
 
     def test_026_delete_flows_cookie_mask_range(self):
         """Test deleting flows with cookie range mask and persistence."""""
@@ -557,7 +576,10 @@ class TestE2EFlowManager:
         self.net.start_controller(enable_all=True, del_flows=True)
         self.net.wait_switches_connect()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        # specially because we used "del_flows=True"
+        time.sleep(15)
 
         # Make sure that flows are soft deleted on /v2/stored_flows
         response = requests.get(
@@ -831,6 +853,7 @@ class TestE2EFlowManager:
         payload = {
             "flows": [
                 {
+                    "cookie": 0x99,
                     "priority": 10,
                     "idle_timeout": 360,
                     "hard_timeout": 1200,
@@ -858,13 +881,15 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
-        assert 'in_port=1' in flows_s1
+        assert len(re.findall("cookie=0x99.*in_port=1 .*output:2", flows_s1)) == 1, flows_s1
 
         # Modify the actions and verify its modification
-        s1.dpctl('mod-flows', 'actions=output:3')
+        # we use output:7 which is a port not in use, to avoid further
+        # problems with loop detection and mismatch links
+        s1.dpctl('mod-flows', 'actions=output:7')
         flows_s1 = s1.dpctl('dump-flows')
         assert 'actions=output:2' not in flows_s1
-        assert 'actions=output:3' in flows_s1
+        assert 'actions=output:7' in flows_s1
 
         if restart_kytos:
             # restart controller keeping configuration
@@ -879,8 +904,8 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
-        assert 'actions=output:3' not in flows_s1
-        assert 'in_port=1' in flows_s1
+        assert 'actions=output:7' not in flows_s1
+        assert len(re.findall("cookie=0x99.*in_port=1 .*output:2", flows_s1)) == 1, flows_s1
 
     def test_040_replace_action_flow(self):
         self.replace_action_flow()
@@ -1068,6 +1093,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] in {"installed", "pending"}
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1107,6 +1134,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] == "deleted"
 
+        time.sleep(5)
+
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
@@ -1129,6 +1158,8 @@ class TestE2EFlowManager:
                       headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1145,6 +1176,9 @@ class TestE2EFlowManager:
         response = requests.delete(api_url, data=json.dumps(payload),
                       headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
+
+        time.sleep(5)
+
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
@@ -1168,6 +1202,8 @@ class TestE2EFlowManager:
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 202, response.text
+
+        time.sleep(5)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -1230,6 +1266,8 @@ class TestE2EFlowManager:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] in {"installed", "pending"}
 
+        time.sleep(5)
+
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -1268,6 +1306,8 @@ class TestE2EFlowManager:
         for sw_flows, length in test_list:
             for flow in sw_flows[BASIC_FLOWS: BASIC_FLOWS + length]:
                 assert flow["state"] == "deleted", flow
+
+        time.sleep(5)
 
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -835,7 +835,9 @@ class TestE2EFlowManager:
         else:
             self.net.reconnect_switches()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        time.sleep(15)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -898,7 +900,9 @@ class TestE2EFlowManager:
         else:
             self.net.reconnect_switches()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        time.sleep(15)
 
         # Check that the flow keeps the original setting
         s1 = self.net.net.get('s1')
@@ -953,7 +957,9 @@ class TestE2EFlowManager:
         else:
             self.net.reconnect_switches()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        time.sleep(15)
 
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
@@ -979,7 +985,9 @@ class TestE2EFlowManager:
         else:
             self.net.reconnect_switches()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        time.sleep(15)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
@@ -1005,7 +1013,9 @@ class TestE2EFlowManager:
         else:
             self.net.reconnect_switches()
 
-        time.sleep(10)
+        # STATS_INTERVAL is set to 7 seconds, we should wait at least
+        # two cycles to account for possible Overlapping requests
+        time.sleep(15)
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')


### PR DESCRIPTION
Related to #432

Fix #234 

Fix #431 

### Summary

- fix time sleeps along tests for flow_manager and mef_eline, to allow time for EVCs to be created and flows to be installed, before running the checks.
- Applied an important change to `test_e2e_20_flow_manager.py::replace_action_flow` on the flow creation to replace the action output=2 to output=7  to avoid conflicts with other NNI interfaces. Before this change, with the output=2, some NNIs would receive LLDP back on their interfaces, which would trigger the Loop Detection and default action to disable the interface, which would take longer to go back to the normal state, and some BASIC flows wouldn't be properly installed/reported.

### Local Tests

N/A

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```