### PR TITLE
Enhancements to make test test_e2e_14_mef_eline.py and test_e2e_70_kytos_stats.py more stable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,17 +15,15 @@ def pytest_terminal_summary(terminalreporter):
     terminalreporter.section('start/stop times', sep='-', bold=True)
     for stat in terminalreporter.stats.values():
         for report in stat:
-            if (
-                hasattr(report, "outcome")
-                and report.outcome == "rerun"
-                and report.when == "call"
-            ):
+            if not hasattr(report, "outcome"):
+                continue
+            if report.outcome == "rerun" and report.when in ("call", "setup"):
                 terminalreporter.write_line(f"rerun: {report.rerun}")
                 start = datetime.fromtimestamp(report.start)
                 stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))
                 terminalreporter.write_line(f"{report.longrepr}")
-            if hasattr(report, 'failed') and report.failed and report.when == 'call':
+            if report.outcome == "failed" and report.when in ("call", "setup"):
                 start = datetime.fromtimestamp(report.start)
                 stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,8 @@ import os
 import requests
 import hashlib
 
+from collections import defaultdict
+
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
@@ -338,9 +340,10 @@ class NetworkTest:
         self.net.orig_configLinkStatus = self.net.configLinkStatus
         self.net.configLinkStatus = self.configLinkStatus
 
-    def start(self):
+    def start(self, start_controller=True):
         self.net.start()
-        self.start_controller(clean_config=True)
+        if start_controller:
+            self.start_controller(clean_config=True)
 
     def drop_database(self):
         """Drop database."""
@@ -423,6 +426,10 @@ class NetworkTest:
 
     def wait_switches_connect(self):
         max_wait = 0
+        # update controller UUIDs for OVSSwitch to avoid errors while changing
+        # the controller: no row "xyz" in table Controller
+        for sw in self.net.switches:
+            sw.controllerUUIDs(update=True)
         while any(not sw.connected() for sw in self.net.switches):
             time.sleep(1)
             max_wait += 1
@@ -430,21 +437,50 @@ class NetworkTest:
                 status = [(sw.name, sw.connected()) for sw in self.net.switches]
                 raise Exception('Timeout: timed out waiting switches reconnect. Status %s' % status)
 
-    def wait_kytos_links(self):
+
+    def wait_kytos_links(self, a=None, b=None, port1=None, port2=None, status=None):
         wait_count = 0
         last_error = ""
         topo_links = []
-        for link in self.net.links:
+        links = self.net.links
+        if a is not None:
+            node_a = self.net.nameToNode.get(a)
+            if not node_a:
+                raise ValueError(f"Invalid node {a}")
+            node_b = None
+            if b is not None:
+                node_b = self.net.nameToNode.get(b)
+                if not node_b:
+                    raise ValueError(f"Invalid node {b}")
+            node_a_links = set()
+            for intf in node_a.intfs.values():
+                if not intf.link:
+                    continue
+                intf2 = intf.link.intf2 if intf.link.intf1 == intf else intf.link.intf1
+                if node_b and intf2.node != node_b:
+                    continue
+                if any([
+                    port1 is not None and not intf.name.endswith(f"eth{port1}"),
+                    port2 is not None and not intf2.name.endswith(f"eth{port2}"),
+                ]):
+                    continue
+                node_a_links.add(intf.link)
+            links = list(node_a_links)
+        for link in links:
             if link.intf1.node in self.net.switches and link.intf2.node in self.net.switches:
                 link_id = self.create_link_id(link)
                 if link_id:
                     topo_links.append(link_id)
-        while wait_count < 30:
+        while wait_count < 60:
             try:
                 response = requests.get("http://127.0.0.1:8181/api/kytos/topology/v3/links/", timeout=3)
                 links = response.json()["links"]
+                if a is not None:
+                    links = {lid: links[lid] for lid in topo_links if lid in links}
                 assert len(topo_links) == len(links), f"{topo_links=} {links=}"
                 assert all(link_id in links for link_id in topo_links), f"{topo_links=} {links=}"
+                if status is not None:
+                    assert all(links[lid]["status"] == status for lid in topo_links), f"{topo_links} {links=} {status=}"
                 break
             except Exception as exc:
                 last_error = str(exc)
@@ -471,6 +507,30 @@ class NetworkTest:
         else:
             raw_str = ":".join(sorted((intf1, intf2)))
         return hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
+
+    def wait_kytos_buff_low_usage(self, max_wait=60, usage_limit=50, period=5):
+        wait_count = 0
+        q_usage = defaultdict(list)
+        while wait_count < max_wait+period:
+            try:
+                response = requests.get("http://127.0.0.1:8181/api/kytos/core/status/", timeout=3)
+                buf_usage = response.json()["buffers_qsize"]
+                moving_avg = {}
+                for name, size in buf_usage.items():
+                    q_usage[name].append(size)
+                    if len(q_usage[name]) > period:
+                        moving_avg[name] = sum(q_usage[name][-period:]) / period
+                    else:
+                        moving_avg[name] = usage_limit+1
+                assert all([usage <= usage_limit for usage in moving_avg.values()]), f"{moving_avg=} {buf_usage=}"
+                break
+            except Exception as exc:
+                last_error = str(exc)
+            time.sleep(1)
+            wait_count += 1
+        else:
+            msg = f"Timeout waiting for low buffer queue usage. Last error: {last_error}"
+            raise Exception(msg)
 
     def restart_kytos_clean(self):
         self.start_controller(clean_config=True, enable_all=True)
@@ -514,7 +574,7 @@ class NetworkTest:
         else:
             connections = node_a.connectionsTo(node_b)
         if len(connections) == 0:
-            error(f"src and dst not connected: {src} {dst}\n")
+            error(f"src and dst not connected: {a} {b}\n")
             return
         # for NoviSwitch hosts, before changing the status of the veth interfaces
         # we need to actually change the status of the interface on the switch to

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -137,7 +137,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.xfail
     def test_030_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
@@ -159,7 +158,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.skip(reason="still needs validaton for negative values")
     def test_035_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
@@ -202,7 +200,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.skip(reason="still needs validation for overflowed values")
     def test_045_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
@@ -297,7 +294,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.xfail
     def test_080_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (invalid value) """
 
@@ -319,7 +315,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.skip(reason="still needs validation for negative values")
     def test_085_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
@@ -362,7 +357,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    @pytest.mark.skip(reason="still needs validation for overflowed values")
     def test_095_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag """
 
@@ -405,8 +399,6 @@ class TestE2EMefEline:
                                   headers={'Content-type': 'application/json'})
         assert response.status_code == 400, response.text
 
-    """It is returning Response [200], should be 400"""
-    @pytest.mark.xfail
     def test_105_patch_an_inconsistent_primary_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -453,8 +445,6 @@ class TestE2EMefEline:
         assert paths == payload1["primary_path"]
         assert data['active'] is True
 
-    """It is returning Response [200], should be 400"""
-    @pytest.mark.xfail
     def test_110_patch_an_unrelated_primary_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -501,7 +491,6 @@ class TestE2EMefEline:
         assert data['active'] is True
 
     """It is returning Response [200], should be 400"""
-    @pytest.mark.xfail
     def test_115_patch_an_empty_primary_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {
@@ -516,11 +505,12 @@ class TestE2EMefEline:
             },
             "primary_path": [
                 {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
-                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:3"}}
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"}}
             ]
         }
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
+        assert response.status_code == 201, response.text
         data = response.json()
         evc1 = data['circuit_id']
 
@@ -541,8 +531,6 @@ class TestE2EMefEline:
         assert data['primary_path'] != []
         assert data['active'] is True
 
-    """It is returning Response [200], should be 400"""
-    @pytest.mark.xfail
     def test_120_patch_an_inconsistent_backup_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -567,6 +555,7 @@ class TestE2EMefEline:
         }
         response = requests.post(api_url, data=json.dumps(payload1),
                                  headers={'Content-type': 'application/json'})
+        assert response.status_code == 201, response.text
         data = response.json()
         evc1 = data['circuit_id']
 
@@ -647,8 +636,7 @@ class TestE2EMefEline:
         assert paths == payload1["backup_path"]
         assert data['active'] is True
 
-    """It is returning Response [500], should be 400"""
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="we dont support primary_links/backup_links")
     def test_130_patch_an_inconsistent_primary_links(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -695,8 +683,7 @@ class TestE2EMefEline:
         assert paths == payload1["primary_links"]
         assert data['active'] is True
 
-    """It is returning Response [500], should be 400"""
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="we dont support primary_links/backup_links")
     def test_135_patch_an_unrelated_primary_links(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -743,8 +730,7 @@ class TestE2EMefEline:
         assert paths == payload1["primary_links"]
         assert data['active'] is True
 
-    """It is returning Response [500], should be 400"""
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="we dont support primary_links/backup_links")
     def test_140_patch_an_inconsistent_backup_links(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -797,8 +783,7 @@ class TestE2EMefEline:
         assert paths == payload1["backup_links"]
         assert data['active'] is True
 
-    """It is returning Response [500], should be 400"""
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="we dont support primary_links/backup_links")
     def test_145_patch_an_unrelated_backup_links(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -895,8 +880,6 @@ class TestE2EMefEline:
         data = response.json()
         assert data['active'] is True
 
-    """It is returning Response 200, should be 400"""
-    @pytest.mark.xfail
     def test_160_patch_request_time(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -21,30 +21,20 @@ class TestE2EMefEline:
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()
-        time.sleep(10)
+        self.net.wait_kytos_links(status="UP")
+        self.net.wait_kytos_buff_low_usage()
+        time.sleep(5)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='amlight')
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):
         cls.net.stop()
 
-    def restart(self, _clean_config=False, _enable_all=True):
-        # Start the controller setting an environment in which the setting is
-        # preserved (persistence) and avoid the default enabling of all elements
-        self.net.start_controller(clean_config=_clean_config, enable_all=_enable_all)
-        self.net.wait_switches_connect()
-
-        # Wait a few seconds to kytos execute LLDP
-        time.sleep(10)
-
-    def wait_sdntrace_result(self, trace_id:int, timeout=11):
+    def wait_sdntrace_result(self, trace_id:int, timeout=30):
         """Wait until sdntrace finishes."""
         wait_count = 0
         while wait_count < timeout:
@@ -174,7 +164,7 @@ class TestE2EMefEline:
         trace_id = self.do_sdntrace('00:00:00:00:00:00:00:16', 2, 100)
         result = self.wait_sdntrace_result(trace_id)
 
-        assert len(result) == 7
+        assert len(result) == 7, str(result)
         assert result[0]["dpid"] == "00:00:00:00:00:00:00:16"
         assert result[1]["dpid"] == "00:00:00:00:00:00:00:15"
         assert result[2]["dpid"] == "00:00:00:00:00:00:00:12"
@@ -350,8 +340,11 @@ class TestE2EMefEline:
         assert not evc_content["current_path"]
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
+        self.net.wait_switches_connect()
+        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="DOWN")
         time.sleep(5)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
+        self.net.wait_kytos_links(status="UP")
         time.sleep(5)
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
@@ -373,8 +366,9 @@ class TestE2EMefEline:
         self.net.net.configLinkStatus('Ampath1', 'Ampath4', 'down')
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'down')
         Ampath1.vsctl(f"set-controller {Ampath1.name} tcp:127.0.0.1:6653")
-        time.sleep(5)
+        time.sleep(10)
         self.net.net.configLinkStatus('Ampath1', 'Ampath3', 'up')
+        self.net.wait_kytos_links('Ampath1', 'Ampath3', status="UP")
         time.sleep(5)
         evc_content = self.get_evc_data(evc)
         current_path = evc_content['current_path' ]
@@ -389,6 +383,7 @@ class TestE2EMefEline:
     def test_030_EVC_path_disjointness(self):
         """Testing disjointness by expecting a specific failover_path."""
         self.net.net.configLinkStatus('Ampath1', 'SoL2', 'down')
+        self.net.wait_kytos_links('Ampath1', 'SoL2', status="DOWN")
         time.sleep(5)
 
         evc = self.create_evc(uni_a='00:00:00:00:00:00:00:15:16',
@@ -418,4 +413,3 @@ class TestE2EMefEline:
         ]
         assert len(failover_path) == len(expected_failover_path)
         assert failover_path == expected_failover_path
-        self.net.net.configLinkStatus('Ampath1', 'SoL2', 'up')

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -15,6 +15,10 @@ class TestE2EOfLLDP:
         cls.net.start()
         cls.net.restart_kytos_clean()
         cls.net.wait_switches_connect()
+        # disable ipv6 router solicitation to avoid interfere with stats
+        for host in cls.net.net.hosts:
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         time.sleep(10)
 
     @classmethod
@@ -78,10 +82,6 @@ class TestE2EOfLLDP:
 
         # make sure the interfaces are actually receiving LLDP
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
-        # disable ipv6 router solicitation to avoid interfere with LLDP stats
-        for host in (h11, h12, h2, h3):
-            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
@@ -147,10 +147,6 @@ class TestE2EOfLLDP:
         time.sleep(5)
 
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
-        # disable ipv6 router solicitation to avoid interfere with LLDP stats
-        for host in (h11, h12, h2, h3):
-            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
         rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
@@ -203,9 +199,6 @@ class TestE2EOfLLDP:
         assert set(data["interfaces"]) == set(expected_interfaces)
 
         h11 = self.net.net.get('h11')
-        # disable ipv6 router solicitation to avoid interfere with LLDP stats
-        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         time.sleep(10)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
@@ -236,9 +229,6 @@ class TestE2EOfLLDP:
         assert data["polling_time"] == default_polling_time
 
         h11 = self.net.net.get('h11')
-        # disable ipv6 router solicitation to avoid interfere with LLDP stats
-        h11.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-        h11.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         lldp_wait = 31
         time.sleep(lldp_wait)

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -19,9 +19,11 @@ class TestE2EKytosStats:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
+        # disable ipv6 router solicitation to avoid interfere with stats
+        for host in cls.net.net.hosts:
+            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
+            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Related to #432

Fix #440 

Fix #441 

Heads-up: this PR requires PR https://github.com/kytos-ng/kytos/pull/621 to be merged first.

### Summary

- enhanced wait_kytos_links() for specific links and status, which helps waiting for a link to become UP or become down before continuing a test
- Augmented `conftest.py` to include information on start/stop times for tests that raised exception and ended up failing during the setup (example: when raising timeout waiting for links).
- Added `start_controller=False` for `net.start()` to allow starting the topology without starting Kytos at first (since it will be restarted as part of the `setup_method()` anyway), and simplify setup_class to avoid excessive Kytos restarts; 
- fixed wait_switches_connect() to force updating the controller UUID otherwise when changing the controllers, OVS would complain that controller UUID was not found
- Added `self.net.wait_kytos_buff_low_usage()` to leverage recent changes on Kytos controller status API to measure the load of the controller before continuing the test (https://github.com/kytos-ng/kytos/pull/621).
- Avoid multiple Kytos restart at the beginning of `test_e2e_70_kytos_stats.py` (setup_method will also restart it)
- Refactor sysctl to disable ipv6 router solicitation on test test_e2e_30_of_lldp
- Applying sysctl to disable IPv6 Router Solicitation (SLAAC) for hosts on test `test_e2e_70_kytos_stats.py` which would impact the statistics observed by the assertions (Issue #440)

### Local Tests

N/A

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```


New execution on the kubernetes cluster with P4OfSwitch backend and the new branches refactored (this one):

```
Tue May 12 20:59:46 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

------------------------------- start/stop times -------------------------------
===== 278 passed, 10 skipped, 7 xfailed, 7 xpassed in 21593.50s (5:59:53) ======
```