### PR TITLE
Introducing the p4ofswitch switch backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,10 +134,12 @@ In the command above _ring_ is the name of the topology. To see all available to
 
   $ grep "lambda.*Topo" tests/helpers.py
 
-Noviflow backend and Telemetry INT tests
+Noviflow and P4OfSwitch backend and Telemetry INT tests
 ########################################
 
 Please refer to the `Noviflow backend integration into Kytos-ng end-to-end tests <misc/README-NoviSwitch.md>`__ for more information.
+
+If you are insterested in the `P4OfSwitch backend integration with Kytos-ng end-to-end tests, click here <misc/README-P4OfSwitch.md>`__.
 
 Requirements
 ############

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -24,18 +24,23 @@ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/TIMEOUT = 0.5/TIMEOUT = 3.0/g' $NAPPS_PATH/var/lib/kytos/napps/amlight/sdntrace/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' $NAPPS_PATH/etc/kytos/logging.ini
-sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' $NAPPS_PATH/etc/kytos/logging.ini
-echo -e "\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka" >> $NAPPS_PATH/etc/kytos/logging.ini
+if ! grep -q aiokafka $NAPPS_PATH/etc/kytos/logging.ini; then
+	sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' $NAPPS_PATH/etc/kytos/logging.ini
+	echo -e "\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka" >> $NAPPS_PATH/etc/kytos/logging.ini
+fi
 
 test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 scripts/setup_kafka.py 2>/dev/null
+python3 scripts/setup_kafka.py
+
+date
 
 python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 

--- a/misc/README-P4OfSwitch.md
+++ b/misc/README-P4OfSwitch.md
@@ -2,6 +2,30 @@
 
 You can run the end-to-end tests with Kytos based on the P4OfSwitch available on Docker image `amlight/p4ofswitch:latest` (Github repo to be published soon) and Mininet with Docker support (Docker-in-Docker exec methodology) based on this forked version (https://github.com/italovalcy/mininet/releases/tag/2.3.2).
 
+The following environment variables can be used to customize the behavior of the end-to-end tests with P4OfSwitch:
+
+- `SWITCH_CLASS`: of cource, this should be set to "P4OfSwitch" to activate the P4OfSwitch backend
+- `P4OFSWITCH_ARCH`: the Tofino Model architecture that will be simulated, it can be `tf1` (Tofino 1 switch, with 64 x 100G ports) or `tf2` (Tofino 2 switch, 32 x 400G ports)
+- `P4OFSWITCH_IMAGE`: the docker image to be used to run the switches, by default it points to `amlight/p4ofswitch:latest` but you can customize to target a testing or pre-release tag, etc.
+- `MYLOCALIP`: if you dont specify, it will be dynamically be obtained using linux `iproute` package (testing connectivity to `8.8.8.8` by default). This parameter is important for configuring the OpenFlow controller on the docker containers running the P4OfAgent switch (keep in mind that we cannot use `127.0.0.1` there, which would point to the container itself, instead of the host running Kytos/mininet)
+
+**Pre-requirements:**
+
+1. Mininet with Docker hosts support (https://github.com/italovalcy/mininet/releases/tag/2.3.2)
+
+2. Docker daemon
+
+3. Memory Huge Pages
+
+To run Tofino Model and `bf_switchd` (open-studio), you are required to provide Kernel Huge Pages memory feature. On our tests, each P4OfSwitch/TofinoModel container will consume around 81 Huge Pages (standard 2MB page size is enough). Since our current biggest topology is AmLightTopo (tests/helpers.py), 1024 huge pages should be enough. Make sure you apply the following setting to your running host:
+
+```
+sysctl vm.nr_hugepages=1024
+mount -t hugetlbfs none /dev/hugepages
+```
+
+## Running with Docker
+
 Follow the steps below to run the tests:
 ```
 docker run -d --name mongo2 mongo:7.0
@@ -41,4 +65,31 @@ cd kytos-end-to-end-tests/
 git checkout feat/p4ofswitch_refactored
 
 tmux new-sess -d -s e2e-tests bash -c 'env TESTS="tests/" RERUNS=2 ./kytos-init.sh 2>&1 | tee e2e-results-1.log; bash'
+```
+
+## Running with Kubernetes
+
+```
+export KUBECONFIG=~/.kube/config
+export E2E_BRANCH=master
+
+kubectl --kubeconfig $KUBECONFIG apply -f misc/kubernetes-kytos-mongo-kafka.yaml
+
+kubectl --kubeconfig $KUBECONFIG rollout status deployment/kytos-regression-tests --timeout=120s
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container mongo1 -- mongosh --eval 'db.getSiblingDB("kytosdb").createUser({user: "kytosuser", pwd: "kytospass", roles: [ { role: "dbAdmin", db: "kytosdb" } ]})'
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- bash -c "sysctl vm.nr_hugepages=1024; service rsyslog start;"
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- git clone --branch $E2E_BRANCH https://github.com/kytos-ng/kytos-end-to-end-tests
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- bash -c "cd /tmp; curl -LO https://github.com/italovalcy/mininet/releases/download/2.3.2/mininet_2.3.2-1--debian12_amd64.deb; apt-get update; apt-get install ./mininet_2.3.2-1--debian12_amd64.deb; apt-get install --no-install-recommends -y gpg"
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- bash -c 'install -m 0755 -d /etc/apt/keyrings  && curl -fsSL https://download.docker.com/linux/debian/gpg     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg  && chmod a+r /etc/apt/keyrings/docker.gpg  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable"     | tee /etc/apt/sources.list.d/docker.list'
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- bash -c "apt-get update && apt-get install --no-install-recommends --no-install-suggests -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- bash -c "setsid dockerd > /var/log/dockerd.log 2>&1 & true; until docker info >/dev/null 2>&1; do sleep 1; done"
+
+kubectl --kubeconfig $KUBECONFIG exec -it deployment/kytos-regression-tests --container kytos -- tmux new-session -d -s kytos-tests -e SWITCH_CLASS=P4OfSwitch -e RERUNS=2 bash -c 'cd kytos-end-to-end-tests/; ./kytos-init.sh 2>&1 | tee /results-kytos-e2e.txt; bash'
 ```

--- a/misc/README-P4OfSwitch.md
+++ b/misc/README-P4OfSwitch.md
@@ -1,0 +1,44 @@
+## Running Kytos end-to-end tests with P4OfSwitch
+
+You can run the end-to-end tests with Kytos based on the P4OfSwitch available on Docker image `amlight/p4ofswitch:latest` (Github repo to be published soon) and Mininet with Docker support (Docker-in-Docker exec methodology) based on this forked version (https://github.com/italovalcy/mininet/releases/tag/2.3.2).
+
+Follow the steps below to run the tests:
+```
+docker run -d --name mongo2 mongo:7.0
+
+docker exec -it mongo2 mongosh --eval 'db.getSiblingDB("k2").createUser({user: "k2", pwd: "k2", roles: [ { role: "dbAdmin", db: "k2" } ]})'
+
+docker run -d --name kafka2 --hostname kafka2 -e KAFKA_NODE_ID=1 -e KAFKA_PROCESS_ROLES=broker,controller -e KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093 -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka2:9092  apache/kafka:4.0.0
+
+docker run -d --name k2 --privileged -v /home/italo/docker:/var/lib/docker -v /lib/modules:/lib/modules --link mongo2 --link kafka2 -e SWITCH_CLASS=P4OfSwitch -e MONGO_DBNAME=k2 -e MONGO_USERNAME=k2 -e MONGO_PASSWORD=k2 -e MONGO_HOST_SEEDS=mongo2:27017  -e KAFKA_HOST_ADDR=kafka2:9092 --pull always --init amlight/kytos:latest /usr/bin/tail -f /dev/null
+
+docker exec -it k2 bash
+
+# all steps below are executed inside the k2 docker container:
+
+apt-get update
+
+apt-get install -y --no-install-recommends --no-install-suggests gnupg
+
+curl -LO https://github.com/italovalcy/mininet/releases/download/2.3.2/mininet_2.3.2-1--debian12_amd64.deb
+
+apt-get install -y ./mininet_2.3.2-1--debian12_amd64.deb
+
+install -m 0755 -d /etc/apt/keyrings  && curl -fsSL https://download.docker.com/linux/debian/gpg     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg  && chmod a+r /etc/apt/keyrings/docker.gpg  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable"     | tee /etc/apt/sources.list.d/docker.list
+
+apt-get update && apt-get install --no-install-recommends --no-install-suggests -y     docker-ce     docker-ce-cli     containerd.io     docker-buildx-plugin     docker-compose-plugin
+
+setsid dockerd > /var/log/dockerd.log 2>&1 &
+
+until docker info > /dev/null 2>&1; do sleep 1; done
+
+docker pull amlight/p4ofswitch:latest
+
+git clone https://github.com/kytos-ng/kytos-end-to-end-tests
+
+cd kytos-end-to-end-tests/
+
+git checkout feat/p4ofswitch_refactored
+
+tmux new-sess -d -s e2e-tests bash -c 'env TESTS="tests/" RERUNS=2 ./kytos-init.sh 2>&1 | tee e2e-results-1.log; bash'
+```

--- a/misc/kubernetes-kytos-mongo-kafka.yaml
+++ b/misc/kubernetes-kytos-mongo-kafka.yaml
@@ -21,10 +21,11 @@ spec:
       containers:
       - name: kytos
         image: amlight/kytos:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 8181
         - containerPort: 6653
-        command: ["/usr/bin/tail", "-f", "/dev/null"]
+        command: ["/usr/bin/tini", "--", "/usr/bin/tail", "-f", "/dev/null"]
         env:
         - name: MONGO_HOST_SEEDS
           value: "127.0.0.1:27017"
@@ -41,15 +42,21 @@ spec:
             type: Unconfined
           capabilities:
             add: ["NET_ADMIN", "SYS_MODULE", "SYS_ADMIN"]
+          privileged: true
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
+        volumeMounts:
+        - name: docker-storage
+          mountPath: /var/lib/docker
       - name: mongo1
         image: mongo:7
+        imagePullPolicy: Always
         ports:
         - containerPort: 27017
       - name: kafka1
         image: apache/kafka:4.0.0
+        imagePullPolicy: Always
         ports:
         - containerPort: 9092
         env:
@@ -76,3 +83,5 @@ spec:
         hostPath:
           path: /lib/modules
           type: Directory
+      - name: docker-storage
+        emptyDir: {}

--- a/scripts/setup_kafka.py
+++ b/scripts/setup_kafka.py
@@ -10,7 +10,7 @@ from aiokafka.admin import AIOKafkaAdminClient, NewTopic
 from aiokafka.errors import KafkaConnectionError
 
 KAFKA_BOOTSTRAP_SERVERS = os.environ.get("KAFKA_HOST_ADDR", "localhost:29092")
-KAFKA_TOPIC = "event_logs"
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "event_logs")
 
 def bootstrap_servers_list(bootstrap_servers: str) -> list[str]:
     """Format the given bootstrap servers into ip:port"""
@@ -30,7 +30,7 @@ async def create_admin_client(bootstrap_servers: list[str]) -> AIOKafkaAdminClie
         print("An unknown error has occurred.")
         raise exc
 
-async def validate_cluster(admin: AIOKafkaAdminClient) -> None:
+async def validate_cluster(admin: AIOKafkaAdminClient) -> int:
     """
     Using an admin client, validate that the cluster is healthy and all the nodes are operational.
 
@@ -40,6 +40,7 @@ async def validate_cluster(admin: AIOKafkaAdminClient) -> None:
     try:
         cluster_metadata: dict[str, Any] = await admin.describe_cluster()
         print(f"Cluster info: {cluster_metadata}")
+        return len(cluster_metadata["brokers"])
     except KafkaConnectionError as exc:
         print("Unable to connect to cluster for validation.")
         raise exc
@@ -58,13 +59,36 @@ async def shutdown(admin: AIOKafkaAdminClient) -> None:
         print("An unknown issue occurred while shutting down.")
         raise exc
 
-async def create_topic(admin: AIOKafkaAdminClient) -> None:
-    """Attempt to create 'event_logs'"""
+async def create_topic(admin: AIOKafkaAdminClient, brokers: int) -> None:
+    """Attempt to delete and then create 'event_logs'"""
+    # 1. Attempt to delete the topic first
     try:
-        await admin.create_topics(
-            [NewTopic(KAFKA_TOPIC, num_partitions=3, replication_factor=3)],
+        print(f"Deleting topic {KAFKA_TOPIC}...")
+        await admin.delete_topics([KAFKA_TOPIC])
+        # Give broker time to update metadata (crucial step)
+        for _ in range(30):
+            topics = await admin.list_topics()
+            if KAFKA_TOPIC not in topics:
+                print(f"Topic {KAFKA_TOPIC} deleted, proceeding to creation.")
+                break
+            await asyncio.sleep(1)
+    except UnknownTopicOrPartitionError:
+        pass
+    except Exception as exc:
+        print(f"Error deleting topic: {e}")
+        raise exc
+
+    try:
+        res = await admin.create_topics(
+            [NewTopic(KAFKA_TOPIC, num_partitions=8, replication_factor=brokers)],
             timeout_ms=5000
         )
+        for name, code, msg in res.topic_errors:
+            if code != 0:
+                raise Exception(
+                    f"Topic creation failed for '{name}' err={code}: {msg}"
+                )
+            print(f"Topic {name} created successfully.")
         await asyncio.sleep(2) # Let the topic propagate
     except KafkaConnectionError as exc:
         print("Unable to create topic.")
@@ -84,10 +108,10 @@ async def main() -> None:
     admin = await create_admin_client(bootstrap_servers)
     print("Admin client was successful! Attempting to validate cluster...")
 
-    await validate_cluster(admin)
+    brokers = await validate_cluster(admin)
     print(f"Cluster was successfully validated! Attempting to create topic '{KAFKA_TOPIC}'...")
 
-    await create_topic(admin)
+    await create_topic(admin, brokers)
     print(f"Topic '{KAFKA_TOPIC}' was created! Attempting to close the admin client...")
 
     await shutdown(admin)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,6 +15,7 @@ from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
 from tests.noviswitch import NoviSwitch
+from tests.p4ofswitch import P4OfSwitch
 
 BASE_ENV = os.environ.get('VIRTUAL_ENV', None) or '/'
 
@@ -27,12 +28,16 @@ NoviSwitch.orig_dpctl = NoviSwitch.dpctl
 NoviSwitch.dpctl = dpctl_wrapper
 OVSSwitch.orig_dpctl = OVSSwitch.dpctl
 OVSSwitch.dpctl = dpctl_wrapper
+P4OfSwitch.orig_dpctl = P4OfSwitch.dpctl
+P4OfSwitch.dpctl = dpctl_wrapper
 
 class SwitchFactory:
     def __new__(cls, *args, **kwargs):
         cls_name = os.environ.get('SWITCH_CLASS')
         if cls_name == "NoviSwitch" and NoviSwitch.is_available():
             return NoviSwitch(*args, **kwargs)
+        if cls_name == "P4OfSwitch":
+            return P4OfSwitch(*args, **kwargs)
         return OVSSwitch(*args, **kwargs)
 
 

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -9,6 +9,8 @@ from mininet.util import quietRun
 
 P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
 
+P4OFSWITCH_IMAGE = os.environ.get("P4OFSWITCH_IMAGE", "amlight/p4ofswitch:latest")
+
 MYLOCALIP = os.environ.get("MYLOCALIP")
 if os.environ.get("SWITCH_CLASS") == "P4OfSwitch" and not MYLOCALIP:
     try:
@@ -33,7 +35,7 @@ class P4OfSwitch(DockerSwitch):
         self.controllers = []
         super().__init__(
             name,
-            image="amlight/p4ofswitch:latest",
+            image=P4OFSWITCH_IMAGE,
             pull="always",
             env=[
                 f"ARCH={self.arch}",

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -1,0 +1,184 @@
+"""P4OfSwitch"""
+
+import os
+import re
+import time
+from mininet.nodelib import DockerSwitch
+from mininet.log import error, info
+from mininet.util import quietRun
+
+P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
+
+MYLOCALIP = os.environ.get("MYLOCALIP")
+if os.environ.get("SWITCH_CLASS") == "P4OfSwitch" and not MYLOCALIP:
+    try:
+        stream = os.popen("ip -j route get 8.8.8.8 | jq -r '.[0].prefsrc'")
+        output = stream.read().strip()
+    except:
+        output = ""
+    if not output:
+        raise ValueError(
+            "Could not identify the Local IP. Please define MYLOCALIP env var"
+            " or check pref ip default router"
+        )
+    MYLOCALIP = output
+
+
+class P4OfSwitch(DockerSwitch):
+    """P4OfSwitch (P4OfAgent + AmLight P4 pipeline)."""
+
+    def __init__(self, name, **kwargs):
+        """create p4ofswitch instance."""
+        self.arch = P4OFSWITCH_ARCH
+        self.controllers = []
+        super().__init__(
+            name,
+            image="amlight/p4ofswitch:latest",
+            pull="always",
+            env=[
+                f"ARCH={self.arch}",
+                "MIN_RETRY_DELAY=2",
+                "MAX_RETRY_DELAY=4",
+            ],
+            volume=[f"/tmp/{name}-logs:/var/log"],
+            **kwargs,
+        )
+
+    def wait_start(self):
+        """Wait until switch has started."""
+        for i in range(300):
+            output = self.cmd("p4ofagent show status system-health")
+            if "System internal status : OK" in output:
+                return True
+            time.sleep(1)
+        raise TimeoutError(f"timeout waiting for switch {self.name} to start")
+
+    def intf_name_to_number(self, intf_name):
+        """Convert interface name into number: s1-eth1 -> 1."""
+        nums = re.findall(r"\d+$", intf_name)
+        return int(nums[0])
+
+    def setup_intf(self, intf):
+        """Setup the interface by enabling it and other confis."""
+        portno = self.intf_name_to_number(intf.name)
+        cmd = f"p4ofagent set config port portno {portno} --portdown off"
+        output = self.cmd(cmd)
+        if output:
+            error(f"Failed to run node={self.name} cmd={cmd}: {outpt}")
+
+    def start(self, controllers):
+        """Start p4ofswitch instance."""
+        self.wait_start()
+
+        # configure DPID
+        dpid = "{:016x}".format(int(self.dpid, 16))
+        dpid = ":".join([dpid[i:i+2] for i in range(0, 16, 2)])
+        output = self.cmd(f"p4ofagent set config switch dpid {dpid}")
+        if output:
+            raise ValueError(
+                f"Failed to configure DPID {dpid} for {self.name}: {output}"
+            )
+
+        # disable all ports and enable ports in use
+        cmd = "p4ofagent --timeout 120 set config port portno all --portdown on"
+        output = self.cmd(cmd)
+        if output:
+            error(f"Failed to run node={self.name} cmd={cmd}: {outpt}")
+        for intf in self.intfs.values():
+            if intf.link:
+                self.setup_intf(intf)
+
+        # configure controllers
+        i = 0
+        for c in controllers:
+            i += 1
+            c_ip = c.IP() if c.IP() not in ["127.0.0.1"] else MYLOCALIP
+            c_port = c.port
+            self.controllers.append((c_ip, c_port))
+            cmd_str = (
+                f"p4ofagent set config controller --ip {c_ip} --port {c_port}"
+                f" --name c{i} --priority {1000+i}"
+            )
+            output = self.cmd(cmd_str)
+            if output:
+                error(
+                    f"\nFailed to run node={self.name} cmd={cmd_str}: {output}"
+                )
+
+    def connected(self):
+        output = self.cmd("p4ofagent show config controller")
+        return "Is connected: True" in output
+
+    def dpctl(self, *args):
+        "Run dpctl command"
+        cmd = f"ovs-ofctl {args[0]} -O OpenFlow13 tcp:127.0.0.1:6653 "
+        cmd += " ".join(args[1:])
+        return self.cmd(cmd)
+
+    def attach(self, intfName):
+        """Connect a data port"""
+        intf = self.nameToIntf.get(intfName)
+        if not intf:
+            error(f"Attached unknown intf {intfName} to {self.name}. Ignoring")
+            return
+        self.setup_intf(intf)
+
+    def reset_controller(self):
+        """Reset the controller connection."""
+        cmd = "p4ofagent set status controller all --reset"
+        return self.cmd(cmd)
+
+    def vsctl(self, *args):
+        """Run vsctl command (try to map from ovs-vsctl)"""
+        if len(args) == 1:
+            args = args[0].split(" ")
+        if args[0] == "del-controller":
+            cmd = "p4ofagent del config controller all"
+            output = self.cmd(cmd)
+            if output:
+                error(f"\nFailed to run name={self.name} cmd={cmd}: {output}")
+            self.controllers = []
+        elif args[0] == "set-controller":
+            cmd = "p4ofagent del config controller all"
+            output = self.cmd(cmd)
+            if output:
+                error(f"\nFailed to run name={self.name} cmd={cmd}: {output}")
+            self.controllers = []
+            i = 0
+            for c in args[2:]:
+                i += 1
+                proto, ip, port = c.split(":")
+                ip = ip if ip not in ["127.0.0.1"] else MYLOCALIP
+                self.controllers.append((ip, port))
+                cmd_str = (
+                    f"p4ofagent set config controller --ip {ip} "
+                    f"--port {port} --name c{i} --priority {1000+i}"
+                )
+                output = self.cmd(cmd_str)
+                if output:
+                    error(
+                        f"\nFailed to run node={self.name} "
+                        f"cmd={cmd_str}: {output}"
+                    )
+        else:
+            logger.error("vsctl command not implemented: %s" % args)
+
+    def controllerUUIDs(self, *args, **kwargs):
+        pass
+
+    def detach(self, intf):
+        """Disconnect a data port"""
+        info(f"Dettach intf {intf} from {self.name} - nothing to do")
+
+    def get_all_of_ports(self):
+        """Get all OpenFlow port numbers."""
+        ports = self.dpctl("dump-ports --no-names")
+        return list(map(int, re.findall(r"\sport\s+([0-9]+):\s", ports)))
+
+    @classmethod
+    def batchShutdown( cls, switches, run=quietRun ):
+        """Shut down a list of P4OfSwitch switches"""
+        run("docker rm -f " + " ".join([sw.name for sw in switches]))
+        for sw in switches:
+            sw.terminate()
+        return switches

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -33,7 +33,7 @@ class TestE2ETopology:
         cls.net.stop()
 
     @pytest.mark.skipif(
-        os.environ.get("SWITCH_CLASS") == "NoviSwitch",
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
         reason="NoviSwitch does not support interface removal",
     )
     def test_010_delete_interface_automatically(self):
@@ -171,7 +171,7 @@ class TestE2ETopology:
         assert response.status_code == 200, f"{response.text}, tries: {counter_tries}"
 
     @pytest.mark.skipif(
-        os.environ.get("SWITCH_CLASS") == "NoviSwitch",
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
         reason="NoviSwitch does not support interface removal",
     )
     def test_025_delete_interface(self):
@@ -280,13 +280,13 @@ class TestE2ETopology:
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        memo_intfs_before = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_before = data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"]
 
         s1_db = self.net.db.switches.find({"id":"00:00:00:00:00:00:00:01"})
         s1_docu = list(s1_db)
         assert len(s1_docu) == 1, "Switch 1 not found"
         db_intfs_before = len(s1_docu[0]["interfaces"])
-        assert memo_intfs_before == db_intfs_before
+        assert len(memo_intfs_before) == db_intfs_before
 
         # Add interface to s1 and s3
         S1, S3 = self.net.net.get('s1', 's3')
@@ -300,13 +300,35 @@ class TestE2ETopology:
         s1_docu = list(s1_db)
         assert len(s1_docu) == 1, "Switch 1 not found"
         db_intfs_after = len(s1_docu[0]["interfaces"])
-        assert db_intfs_after == db_intfs_before + 1
+
+        # Noviflow and P4OfSwitch switches does not actually create a new
+        # interface here. They will create a new interface when adding a LAG
+        # logical port or creating a breakdown, but we will have another test
+        # for that
+        if os.environ.get("SWITCH_CLASS") not in ("NoviSwitch", "P4OfSwitch"):
+            assert db_intfs_after == db_intfs_before + 1
 
         # Look for new interface in the memory
         api_url = f'{KYTOS_API}/topology/v3/'
         response = requests.get(api_url)
         data = response.json()
-        memo_intfs_after = len(data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"])
+        memo_intfs_after = data["topology"]["switches"]["00:00:00:00:00:00:00:01"]["interfaces"]
 
-        assert memo_intfs_after == memo_intfs_before + 1
-        assert db_intfs_after == memo_intfs_after
+        # Noviflow and P4OfSwitch switches does not create a new interface, but
+        # port 20 should be active now.
+        if os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"):
+            for intf_id, intf in memo_intfs_before.items():
+                if intf_id == "00:00:00:00:00:00:00:01:20":
+                    assert intf["active"] == False, f"should be down: {intf}"
+                    break
+            else:
+                pytest.fail(f"intf not found on sw1 before {memo_intfs_after}")
+            for intf_id, intf in memo_intfs_after.items():
+                if intf_id == "00:00:00:00:00:00:00:01:20":
+                    assert intf["active"] == True, f"should be up: {intf}"
+                    break
+            else:
+                pytest.fail(f"intf not found on sw1 after {memo_intfs_after}")
+        else:
+            assert len(memo_intfs_after) == len(memo_intfs_before) + 1
+        assert db_intfs_after == len(memo_intfs_after)

--- a/tests/test_e2e_95_telemtry_int.py
+++ b/tests/test_e2e_95_telemtry_int.py
@@ -1,6 +1,7 @@
 """End-to-end tests for telemetry_int Napp."""
 
 import os
+import re
 import time
 from pathlib import Path
 
@@ -27,8 +28,11 @@ def parse_int_collector(data):
 
 
 @pytest.mark.skipif(
-    os.environ.get("SWITCH_CLASS") != "NoviSwitch"
-    or os.environ.get("NOVIVERSION") != "NW570.6.1",
+    os.environ.get("SWITCH_CLASS") not in ("NoviSwitch", "P4OfSwitch")
+    or (
+        os.environ.get("SWITCH_CLASS") == "NoviSwitch"
+        and os.environ.get("NOVIVERSION") != "NW570.6.1"
+    ),
     reason="NoviSwitch does not support interface removal",
 )
 class TestE2ETelemtryINT:
@@ -50,7 +54,7 @@ class TestE2ETelemtryINT:
     def setup_class(cls):
         """Called once before all test methods within a class are run."""
         cls.net = NetworkTest(CONTROLLER, topo_name="amlight_intlab")
-        cls.net.start()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):
@@ -113,9 +117,8 @@ class TestE2ETelemtryINT:
         expected_counts: list[tuples] (switch_obj, expected_int)
         """
         for switch, count in expected_counts:
-            flows = switch.dpctl(
-                "dump-flows", f"cookie=0xa0{evc_id}/0xf0ffffffffffffff"
-            ).splitlines()
+            flows = switch.dpctl("dump-flows").splitlines()
+            flows = [flow for flow in flows if re.search(rf"cookie=0xa.{evc_id}", flow)]
             assert len(flows) == count, f"Wrong flows length for {switch}: {flows}"
 
     def validate_traffic(self, src, dst):
@@ -152,16 +155,28 @@ class TestE2ETelemtryINT:
         self.config_host_ip_vlan(h3, "10.1.98.3", 198)
 
         # enable INT Collector on switches
-        s1.novi_cmd(
-            "set config int monitor portno 3 ethdst 00:00:00:00:02:01 ethsrc 00:00:00:aa:aa:01 "
-            "ipv4src 10.255.255.1 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
-        )
-        s1.novi_cmd("set config int maxhopcount 10")
-        s6.novi_cmd(
-            "set config int monitor portno 3 ethdst 00:00:00:00:02:03 ethsrc 00:00:00:aa:aa:06 "
-            "ipv4src 10.255.255.6 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
-        )
-        s6.novi_cmd("set config int maxhopcount 10")
+        if os.environ.get("SWITCH_CLASS") == "NoviSwitch":
+            s1.novi_cmd(
+                "set config int monitor portno 3 ethdst 00:00:00:00:02:01 ethsrc 00:00:00:aa:aa:01 "
+                "ipv4src 10.255.255.1 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
+            )
+            s1.novi_cmd("set config int maxhopcount 10")
+            s6.novi_cmd(
+                "set config int monitor portno 3 ethdst 00:00:00:00:02:03 ethsrc 00:00:00:aa:aa:06 "
+                "ipv4src 10.255.255.6 ipv4dst 10.255.255.254 udpsrc 6000 udpdst 5900 maxlen 320"
+            )
+            s6.novi_cmd("set config int maxhopcount 10")
+        elif os.environ.get("SWITCH_CLASS") == "P4OfSwitch":
+            s1.cmd(
+                "p4ofagent set config int --of_port_no 3 --src_mac 00:00:00:aa:aa:01 --dst_mac 00:00:00:00:02:01 "
+                "--src_ip 10.255.255.1 --dst_ip 10.255.255.254 --dst_udp 5900 --max_pkt_len 320"
+            )
+            s6.cmd(
+                "p4ofagent set config int --of_port_no 3 --src_mac 00:00:00:aa:aa:06 --dst_mac 00:00:00:00:02:03 "
+                "--src_ip 10.255.255.6 --dst_ip 10.255.255.254 --dst_udp 5900 --max_pkt_len 320"
+            )
+        else:
+            pytest.fail("Unsupported SWITCH_CLASS. Supported values: NoviSwitch, P4OfSwitch")
 
         # start int collector
         h2.cmd(
@@ -255,8 +270,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:7 -- s6:7
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "down")
+        self.net.wait_kytos_links("s1", "s6", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:5", "00:00:00:00:00:00:00:05:5"],
@@ -317,8 +333,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s1:5 -- s5:5
         #####################################################
         self.net.net.configLinkStatus("s1", "s5", "down")
+        self.net.wait_kytos_links("s1", "s5", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -380,8 +397,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:5 -- s6:5
         #####################################################
         self.net.net.configLinkStatus("s2", "s6", "down")
+        self.net.wait_kytos_links("s2", "s6", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -456,8 +474,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:8 -- s6:8
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=8, port2=8)
+        self.net.wait_kytos_links("s5", "s6", port1=8, port2=8, status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -540,8 +559,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s2:4 -- s3:4
         #####################################################
         self.net.net.configLinkStatus("s2", "s3", "down")
+        self.net.wait_kytos_links("s2", "s3", status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:6", "00:00:00:00:00:00:00:02:6"],
@@ -604,8 +624,9 @@ class TestE2ETelemtryINT:
         ## simulate link down on current path: s5:9 -- s6:9
         #####################################################
         self.net.net.configLinkStatus("s5", "s6", "down", port1=9, port2=9)
+        self.net.wait_kytos_links("s2", "s3", port1=9, port2=9, status="DOWN")
 
-        time.sleep(15)
+        time.sleep(5)
 
         self.validate_evc_paths(evc_id, [], [])
 
@@ -622,8 +643,9 @@ class TestE2ETelemtryINT:
         ## simulate link UP on s1 -- s6 to check if the EVC will recover
         #####################################################
         self.net.net.configLinkStatus("s1", "s6", "up")
+        self.net.wait_kytos_links("s1", "s6", status="UP")
 
-        time.sleep(15)
+        time.sleep(5)
 
         expected_current = [
             ["00:00:00:00:00:00:00:01:7", "00:00:00:00:00:00:00:06:7"],


### PR DESCRIPTION
Closes #432

### Summary

- Adding the P4OfSwitch backend to run. tests against AmLight's P4 Pipeline + P4OfAgent based on docker hosts. Please refer to `misc/README-P4OfSwitch.md` for more documentation.
- Changed setup_kafka.py script to first delete the topic and then create it. Also, accounting for a dynamic number of Brokers when setting up the new topic. Finally, changing the number of partitions, which had a significant impact on the timeout errors that were being observed before.
- Slightly changed the `kytos-init.sh` script to avoid adding the kafka log configs multiple times to `/etc/kytos/logging.ini` if you run multiple times on the same environment 
- Adjusting tests/test_06 and telemetry tests (tests/test_95) to use the P4OfSwitch backend

### Local Tests

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```