### PR TITLE
added test_040_new_interface_allocated_lldp_vlan

### DIFF
--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -2,6 +2,7 @@ import requests
 from tests.helpers import NetworkTest
 import time
 import pytest
+import os
 
 CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -270,3 +270,51 @@ class TestE2EOfLLDP:
                 if link.intf1.name == "s1-eth5" or link.intf2.name == "s1-eth5":
                     self.net.net.delLink(link)
                     break
+
+    def test_041_lldp_flow_installed_after_switch_enable(self):
+        """of_lldp must not install the VLAN 3799 flow while switches are
+        disabled on every interface that exposes tag ranges."""
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
+        time.sleep(10)
+
+        api_url = KYTOS_API + '/topology/v3/switches'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        switches = response.json().get("switches", {})
+        assert switches, "no switches found in topology"
+        dpids = list(switches.keys())
+        for dpid in dpids:
+            assert switches[dpid]["enabled"] is False, dpid
+
+        def has_lldp_flow(dpid):
+            stored_url = f"{KYTOS_API}/flow_manager/v2/stored_flows/?dpid={dpid}"
+            stored = requests.get(stored_url)
+            assert stored.status_code == 200, stored.text
+            flows = stored.json().get(dpid, [])
+            return any(
+                f["flow"].get("match", {}).get("dl_vlan") == 3799
+                for f in flows
+            )
+
+        for dpid in dpids:
+            assert not has_lldp_flow(dpid), f"unexpected LLDP flow on {dpid}"
+
+        self.enable_all_interfaces()
+        time.sleep(10)
+
+        for dpid in dpids:
+            assert has_lldp_flow(dpid), f"missing LLDP flow on {dpid}"
+
+        tags_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
+        response = requests.get(tags_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        for intf_id, intf_data in data.items():
+            available = intf_data.get("available_tags", {}).get("vlan")
+            if not available:
+                continue
+            for start, end in available:
+                assert not (start <= 3799 <= end), (
+                    f"{intf_id} still has VLAN 3799 in available_tags: {available}"
+                )

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -224,6 +224,10 @@ class TestE2EOfLLDP:
         # the delta pps now should be around 30, because the interval is every 1s
         assert delta_pps_2 > delta_pps + 15
 
+    @pytest.mark.skipif(
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
+        reason="NoviSwitch/P4OfSwitch already include all interface when connecting",
+    )
     def test_040_new_interface_allocated_lldp_vlan(self):
         """New interface hot-added to ring topology must be picked up by of_lldp
         within 5s, with VLAN 3799 absent from available_tags (reserved by of_lldp)."""

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -1,6 +1,7 @@
 import requests
 from tests.helpers import NetworkTest
 import time
+import pytest
 
 CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -223,3 +223,50 @@ class TestE2EOfLLDP:
 
         # the delta pps now should be around 30, because the interval is every 1s
         assert delta_pps_2 > delta_pps + 15
+
+    def test_040_new_interface_allocated_lldp_vlan(self):
+        """New interface hot-added to ring topology must be picked up by of_lldp
+        within 5s, with VLAN 3799 absent from available_tags (reserved by of_lldp)."""
+        self.net.restart_kytos_clean()
+        time.sleep(5)
+
+        new_intf_s1 = "00:00:00:00:00:00:00:01:5"
+        new_intf_s2 = "00:00:00:00:00:00:00:02:4"
+
+        api_url = KYTOS_API + "/of_lldp/v1/interfaces/"
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        intfs_before = set(response.json()["interfaces"])
+        assert new_intf_s1 not in intfs_before
+        assert new_intf_s2 not in intfs_before
+
+        # Add a new link between s1 (port 5) and s2 (port 4)
+        S1, S2 = self.net.net.get("s1", "s2")
+        self.net.net.addLink(S1, S2, port1=5, port2=4)
+        S1.attach("s1-eth5")
+        S2.attach("s2-eth4")
+        try:
+            time.sleep(5)
+
+            response = requests.get(api_url)
+            assert response.status_code == 200, response.text
+            intfs_after = set(response.json()["interfaces"])
+            assert new_intf_s1 in intfs_after, f"{intfs_after}"
+            assert new_intf_s2 in intfs_after, f"{intfs_after}"
+
+            # Assert VLAN 3799 is NOT in available_tags
+            expected_available = [[1, 3798], [3800, 4094]]
+            topo_url = KYTOS_API + "/topology/v3/interfaces/tag_ranges"
+            response = requests.get(topo_url)
+            assert response.status_code == 200, response.text
+            data = response.json()
+            for intf_id in (new_intf_s1, new_intf_s2):
+                actual = data[intf_id]["available_tags"]["vlan"]
+                assert actual == expected_available, f"{intf_id} available_tags: {actual}"
+        finally:
+            S1.detach("s1-eth5")
+            S2.detach("s2-eth4")
+            for link in self.net.net.linksBetween(S1, S2):
+                if link.intf1.name == "s1-eth5" or link.intf2.name == "s1-eth5":
+                    self.net.net.delLink(link)
+                    break


### PR DESCRIPTION
Related to https://github.com/kytos-ng/of_lldp/issues/130
Closes https://github.com/kytos-ng/kytos-end-to-end-tests/issues/445

### Summary

Added new test cases to cover related issue, especially since the subscribed events changed on of_lldp

### End-to-End Tests

Ran new test suite and entire test suite with respective related of_core and of_lldp branches:

```
+ python3 -m pytest tests/ -k test_040_new_interface_allocated_lldp_vlan --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 304 items / 303 deselected / 1 selected
tests/test_e2e_30_of_lldp.py .                                           [100%]
=============================== warnings summary ===============================
tests/test_e2e_30_of_lldp.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_30_of_lldp.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 303 deselected, 34 warnings in 73.04s (0:01:13) ===========
```

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 303 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 280 passed, 9 skipped, 7 xfailed, 7 xpassed, 1394 warnings in 14516.41s (4:01:56) =
```