### PR TITLE
added test_120_install_and_delete_ipv6_flow

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -17,7 +17,7 @@ fi
 # the settings below are intended to decrease the tests execution time (in fact, the time.sleep() calls
 # depend on the values below, otherwise many tests would fail)
 sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_core/settings.py
-sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/flow_manager/settings.py
+sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 14/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' $NAPPS_PATH/var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' $NAPPS_PATH/var/lib/kytos/napps/kytos/of_lldp/settings.py

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 import re
 
@@ -1325,3 +1326,81 @@ class TestE2EFlowManager:
         assert len(flows_s1.splitlines()) == BASIC_FLOWS, flows_s1
         assert len(flows_s2.splitlines()) == BASIC_FLOWS, flows_s2
         assert len(flows_s3.splitlines()) == BASIC_FLOWS, flows_s3
+
+    def test_120_install_and_delete_ipv6_flow(self):
+        """Tests if, after kytos restart, a flow deleted
+        from a switch will still be deleted."""
+        consistency_counter = 0
+        if os.path.exists("/var/log/syslog"):
+            with open("/var/log/syslog", "r") as f:
+               consistency_counter = len(re.findall(r'flow_manager.*Consistency check', f.read()))
+
+        payload = {
+            "flows": [
+                {
+                    "table_id": 0,
+                    "cookie": 20120,
+                    "match": {"in_port": 1, 'dl_type': 0x86dd},
+                    "instructions": [
+                        {
+                            "instruction_type": "goto_table",
+                            "table_id": 3,
+                        },
+                    ],
+                },
+                {
+                    "table_id": 3,
+                    "cookie": 20120,
+                    "match": {
+                        "in_port": 1,
+                        "ipv6_dst": "2001:db8:0:100::1",
+                        'dl_type': 0x86dd,
+                    },
+                    'actions': [{'action_type': 'output', 'port': 2}]
+                },
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        requests.post(api_url, json=payload)
+
+        # wait for the flow to be installed and flow_manager's MIN veridict timer
+        time.sleep(16)
+
+        # make sure the flows were installed
+        s1 = self.net.net.get('s1')
+        flows_s1 = s1.dpctl('dump-flows')
+        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 2, flows_s1
+        assert '2001:db8:0:100' in flows_s1
+
+        # del flows from table 3 and wait for consistency check to reinstall
+        # them. STATS_INTERVAL is 7 sec, so we wait at least 2 cycles
+        s1.dpctl("del-flows table=3")
+        time.sleep(15)
+
+        # make sure consistency check will push the flows back
+        flows_s1 = s1.dpctl('dump-flows')
+        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 2, flows_s1
+        assert '2001:db8:0:100' in flows_s1
+
+        if os.path.exists("/var/log/syslog"):
+            with open("/var/log/syslog", "r") as f:
+               entries = re.findall(r'flow_manager.*Consistency check', f.read())
+            assert len(entries) == consistency_counter, str(entries)
+
+        # delete the flows
+        payload["flows"][0]["cookie_mask"] = 18446744073709551615
+        payload["flows"][1]["cookie_mask"] = 18446744073709551615
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.delete(api_url, json=payload)
+        assert response.status_code == 202, response.text
+        data = response.json()
+        assert 'FlowMod Messages Sent' in data['response']
+
+        # wait for the flow to be deleted
+        time.sleep(10)
+
+        # make sure flows were deleted
+        flows_s1 = s1.dpctl('dump-flows')
+        assert len(flows_s1.splitlines()) == BASIC_FLOWS, flows_s1
+        assert '2001:db8:0:100' not in flows_s1


### PR DESCRIPTION
Closes #443 

### Summary

Added new test case to cover related issue, especially adding flows related to IPv6 matching fields (in its compressed form, which used to create problems)

### End-to-End Tests

Local tests with this new test *without* applying the patch from PR https://github.com/kytos-ng/of_core/pull/159/

```
+ date
Thu May 14 23:53:20 UTC 2026
+ python3 -m pytest tests/test_e2e_20_flow_manager.py -k test_120_install_and_delete_ipv6_flow --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 29 items / 28 deselected / 1 selected

tests/test_e2e_20_flow_manager.py F                                      [100%]

=================================== FAILURES ===================================
___________ TestE2EFlowManager.test_120_install_and_delete_ipv6_flow ___________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager object at 0x7f1bf73da390>

    def test_120_install_and_delete_ipv6_flow(self):
        """Tests if, after kytos restart, a flow deleted
        from a switch will still be deleted."""
        consistency_counter = 0
        if os.path.exists("/var/log/syslog"):
            with open("/var/log/syslog", "r") as f:
               consistency_counter = len(re.findall(r'flow_manager.*Consistency check', f.read()))

        payload = {
            "flows": [
                {
                    "table_id": 0,
                    "cookie": 20120,
                    "match": {"in_port": 1, 'dl_type': 0x86dd},
                    "instructions": [
                        {
                            "instruction_type": "goto_table",
                            "table_id": 3,
                        },
                    ],
                },
                {
                    "table_id": 3,
                    "cookie": 20120,
                    "match": {
                        "in_port": 1,
                        "ipv6_dst": "2001:db8:0:100::1",
                        'dl_type': 0x86dd,
                    },
                    'actions': [{'action_type': 'output', 'port': 2}]
                },
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        requests.post(api_url, json=payload)

        # wait for the flow to be installed and flow_manager's MIN veridict
        # timer (14s)
        time.sleep(16)

        # make sure the flows were installed
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
>       assert len(flows_s1.splitlines()) == BASIC_FLOWS + 2, flows_s1
E       AssertionError:  cookie=0xab00000000000001, duration=29.061s, table=0, n_packets=20, n_bytes=840, send_flow_rem priority=50000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
E          cookie=0xac00000000000001, duration=28.496s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
E          cookie=0xac00000000000001, duration=28.365s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
E          cookie=0x4e98, duration=16.006s, table=0, n_packets=1, n_bytes=70, send_flow_rem ipv6,in_port=1 actions=goto_table:3
E
E       assert 4 == (3 + 2)
E        +  where 4 = len([' cookie=0xab00000000000001, duration=29.061s, table=0, n_packets=20, n_bytes=840, send_flow_rem priority=50000,dl_vl... cookie=0x4e98, duration=16.006s, table=0, n_packets=1, n_bytes=70, send_
flow_rem ipv6,in_port=1 actions=goto_table:3'])
E        +    where [' cookie=0xab00000000000001, duration=29.061s, table=0, n_packets=20, n_bytes=840, send_flow_rem priority=50000,dl_vl... cookie=0x4e98, duration=16.006s, table=0, n_packets=1, n_bytes=70, send_flow_r
em ipv6,in_port=1 actions=goto_table:3'] = <built-in method splitlines of str object at 0x2cca370>()
E        +      where <built-in method splitlines of str object at 0x2cca370> = ' cookie=0xab00000000000001, duration=29.061s, table=0, n_packets=20, n_bytes=840, send_flow_rem priority=50000,dl_vla...okie=0x4e98, durati
on=16.006s, table=0, n_packets=1, n_bytes=70, send_flow_rem ipv6,in_port=1 actions=goto_table:3\r\n'.splitlines

tests/test_e2e_20_flow_manager.py:1373: AssertionError
---------------------------- Captured stderr setup -----------------------------
...
------------------------------- start/stop times -------------------------------
tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_120_install_and_delete_ipv6_flow: 2026-05-14,23:54:12.723050 - 2026-05-14,23:54:28.933993
=========================== short test summary info ============================
FAILED tests/test_e2e_20_flow_manager.py::TestE2EFlowManager::test_120_install_and_delete_ipv6_flow
============ 1 failed, 28 deselected, 1 warning in 69.88s (0:01:09) ============
```

Now with the PR https://github.com/kytos-ng/of_core/pull/159  applied and using OVS switch backend:

```
+ date
Thu May 14 23:48:46 UTC 2026
+ python3 -m pytest tests/test_e2e_20_flow_manager.py -k test_120_install_and_delete_ipv6_flow --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 29 items / 28 deselected / 1 selected

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
...
------------------------------- start/stop times -------------------------------
============ 1 passed, 28 deselected, 1 warning in 95.64s (0:01:35) ============
```

Finally, with PR https://github.com/kytos-ng/of_core/pull/159 applied and with P4OfSwitch backend:

```
+ date
Thu May 14 23:57:01 UTC 2026
+ python3 -m pytest tests/test_e2e_20_flow_manager.py -k test_120_install_and_delete_ipv6_flow --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 29 items / 28 deselected / 1 selected

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
=========== 1 passed, 28 deselected, 1 warning in 306.03s (0:05:06) ============
```


Full exec of the end-to-end tests with both PRs applied (OVS backend) -- please be advised that the reruns below [were narrowed down to a possible problem on a of_lldp change](https://github.com/kytos-ng/of_lldp/pull/131#issuecomment-4488223412) that was also being evaluated along with this:

```
+ date
Mon May 18 08:33:11 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 304 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py .....R.....ss.....x...................... [ 22%]
..                                                                       [ 22%]
tests/test_e2e_11_mef_eline.py R........                                 [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py .R...                                       [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py ....R.                               [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

------------------------------- start/stop times -------------------------------
rerun: 0
tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_035_create_evc_same_vid_different_uni: 2026-05-18,09:01:26.042581 - 2026-05-18,09:01:46.601132
self = <tests.test_e2e_10_mef_eline.TestE2EMefEline object at 0x7f63f00123d0>

    def test_035_create_evc_same_vid_different_uni(self):
        # Create circuit 1
        payload = {
            "name": "Vlan110_Test",
            "enabled": True,
            "dynamic_backup_path": True,
            "uni_a": {
                "interface_id": "00:00:00:00:00:00:00:01:1",
                "tag": {"tag_type": 1, "value": 110}
            },
            "uni_z": {
                "interface_id": "00:00:00:00:00:00:00:02:1",
                "tag": {"tag_type": 1, "value": 110}
            }
        }
        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
        assert response.status_code == 201, response.text
        data = response.json()
        assert 'circuit_id' in data
        evc1 = data['circuit_id']
        time.sleep(10)

        # Create circuit 2: same vlan id but in different UNIs
        payload = {
            "name": "Vlan110_Test2",
            "enabled": True,
            "dynamic_backup_path": True,
            "uni_a": {
                "interface_id": "00:00:00:00:00:00:00:01:2",
                "tag": {"tag_type": "vlan", "value": 110}
            },
            "uni_z": {
                "interface_id": "00:00:00:00:00:00:00:03:1",
                "tag": {"tag_type": "vlan", "value": 110}
            }
        }
        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
        assert response.status_code == 201, response.text
        data = response.json()
        assert 'circuit_id' in data
        evc2 = data['circuit_id']
        assert evc1 != evc2
        time.sleep(10)

        # Switch s1 should have BASIC_FLOWS + 3 for evc1 + 3 for evc2
        # Switch s2 should have BASIC_FLOWS + 3 for evc1 + 2 for evc2/failover
        # Switch s2 should have BASIC_FLOWS + 3 for evc2 + 2 for evc1/failover
        s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
        flows_s1 = s1.dpctl('dump-flows')
        flows_s2 = s2.dpctl('dump-flows')
        flows_s3 = s3.dpctl('dump-flows')
        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 6, flows_s1
>       assert len(flows_s2.splitlines()) == BASIC_FLOWS + 5, flows_s2
E       AssertionError:  cookie=0xac00000000000002, duration=32.865s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
E          cookie=0xac00000000000002, duration=32.746s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:01 actions=CONTROLLER:65535
E          cookie=0xaa820bb3d0bebc4f, duration=20.279s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=1,dl_vlan=110 actions=push_vlan:0x88a8,set_field:4097->vlan_vid,output:2
E          cookie=0xaa820bb3d0bebc4f, duration=20.274s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=2,dl_vlan=1 actions=pop_vlan,output:1
E          cookie=0xaa820bb3d0bebc4f, duration=20.037s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=3,dl_vlan=1 actions=pop_vlan,output:1
E          cookie=0xaa9b2a7e48378848, duration=9.781s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=2,dl_vlan=2 actions=set_field:4098->vlan_vid,output:3
E          cookie=0xaa9b2a7e48378848, duration=9.774s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=3,dl_vlan=2 actions=set_field:4098->vlan_vid,output:2
E
E       assert 7 == (3 + 5)
E        +  where 7 = len([' cookie=0xac00000000000002, duration=32.865s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=e...packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=2,dl_vlan=2 actions=set_field:4098->vlan_vid,output:3', ...])
E        +    where [' cookie=0xac00000000000002, duration=32.865s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=e...packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=2,dl_vlan=2 actions=set_field:4098->vlan_vid,output:3', ...] = <built-in method splitlines of str object at 0xd384580>()
E        +      where <built-in method splitlines of str object at 0xd384580> = ' cookie=0xac00000000000002, duration=32.865s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee...n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=3,dl_vlan=2 actions=set_field:4098->vlan_vid,output:2\r\n'.splitlines

tests/test_e2e_10_mef_eline.py:379: AssertionError
rerun: 0
tests/test_e2e_11_mef_eline.py::TestE2EMefEline::test_005_on_primary_path_fail_should_migrate_to_backup: 2026-05-18,09:41:18.003038 - 2026-05-18,09:41:38.210322
self = <tests.test_e2e_11_mef_eline.TestE2EMefEline object at 0x7f63efe09350>

    def test_005_on_primary_path_fail_should_migrate_to_backup(self):

        # TODO Check for false positives between uni_a switch 1 and uni_z switch 3 instead of switch 2
        """ When the primary_path is down and backup_path exists and is UP
            the circuit will change from primary_path to backup_path. """
        payload = {
            "name": "my evc1",
            "enabled": True,
            "uni_a": {
                "interface_id": "00:00:00:00:00:00:00:01:1",
                "tag": {
                    "tag_type": 1,
                    "value": 101
                }
            },
            "uni_z": {
                "interface_id": "00:00:00:00:00:00:00:02:1",
                "tag": {
                    "tag_type": "vlan",
                    "value": 101
                }
            },
            "primary_path": [
                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:3"}}
            ],
            "backup_path": [
                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:4"},
                 "endpoint_b": {"id": "00:00:00:00:00:00:00:04:4"}},
                {"endpoint_a": {"id": "00:00:00:00:00:00:00:04:3"},
                 "endpoint_b": {"id": "00:00:00:00:00:00:00:03:4"}},
                {"endpoint_a": {"id": "00:00:00:00:00:00:00:03:1"},
                 "endpoint_b": {"id": "00:00:00:00:00:00:00:02:4"}}
            ]
        }

        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
        assert response.status_code == 201, response.text

        time.sleep(10)

        # Command to up/down links to test if back-up path is taken
        self.net.net.configLinkStatus('s1', 's2', 'down')

        # Wait just a few seconds to give time to the controller receive and process the linkDown event
        time.sleep(10)

        # Check on the virtual switches directly for flows
        s1, s2, s3, s4 = self.net.net.get('s1', 's2', 's3', 's4')
        flows_s1 = s1.dpctl('dump-flows')
        flows_s2 = s2.dpctl('dump-flows')
        flows_s3 = s3.dpctl('dump-flows')
        flows_s4 = s4.dpctl('dump-flows')
>       assert len(flows_s1.splitlines()) == BASIC_FLOWS + 2, flows_s1
E       AssertionError:  cookie=0xac00000000000001, duration=31.832s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:04 actions=CONTROLLER:65535
E          cookie=0xac00000000000001, duration=31.660s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
E          cookie=0xaa7d01767fbf5a4e, duration=9.534s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=1,dl_vlan=101 actions=push_vlan:0x88a8,set_field:4097->vlan_vid,output:4
E          cookie=0xaa7d01767fbf5a4e, duration=9.530s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=4,dl_vlan=1 actions=pop_vlan,output:1
E
E       assert 4 == (3 + 2)
E        +  where 4 = len([' cookie=0xac00000000000001, duration=31.832s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=e...n=9.530s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=4,dl_vlan=1 actions=pop_vlan,output:1'])
E        +    where [' cookie=0xac00000000000001, duration=31.832s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=e...n=9.530s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=4,dl_vlan=1 actions=pop_vlan,output:1'] = <built-in method splitlines of str object at 0xd383900>()
E        +      where <built-in method splitlines of str object at 0xd383900> = ' cookie=0xac00000000000001, duration=31.832s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=50000,dl_src=ee....530s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=20000,in_port=4,dl_vlan=1 actions=pop_vlan,output:1\r\n'.splitlines

tests/test_e2e_11_mef_eline.py:100: AssertionError
rerun: 0
tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_002_disable_link_liveness: 2026-05-18,11:25:21.791964 - 2026-05-18,11:25:26.836626
self = <tests.test_e2e_31_of_lldp.TestE2EOfLLDP object at 0x7f63efee6650>

    def test_002_disable_link_liveness(self) -> None:
        """Test disable link liveness."""
        polling_interval = 1
        self.set_polling_time(polling_interval)
        interface_ids = [
            "00:00:00:00:00:00:00:03:2",
            "00:00:00:00:00:00:00:02:3",
            "00:00:00:00:00:00:00:01:3",
            "00:00:00:00:00:00:00:02:2",
            "00:00:00:00:00:00:00:01:4",
            "00:00:00:00:00:00:00:03:3",
        ]
        self.enable_link_liveness(interface_ids)

        # Wait just so liveness can go up
        time.sleep(polling_interval * 5)

        # Assert GET liveness/ is enabled
        api_url = f"{KYTOS_API}/of_lldp/v1/liveness/"
        response = requests.get(api_url)
        data = response.json()
        for entry in data["interfaces"]:
            assert entry["id"] in interface_ids, entry
>           assert entry["status"] == "up", entry
E           AssertionError: {'id': '00:00:00:00:00:00:00:03:2', 'last_hello_at': None, 'status': 'init'}
E           assert 'init' == 'up'
E
E             - up
E             + init

tests/test_e2e_31_of_lldp.py:165: AssertionError
rerun: 0
tests/test_e2e_60_of_multi_table.py::TestE2EOfMultiTable::test_020_invalid_pipelines: 2026-05-18,12:22:16.376084 - 2026-05-18,12:23:32.052392
self = <tests.test_e2e_60_of_multi_table.TestE2EOfMultiTable object at 0x7f63ee34a690>
method = <bound method TestE2EOfMultiTable.test_020_invalid_pipelines of <tests.test_e2e_60_of_multi_table.TestE2EOfMultiTable object at 0x7f63ee34a690>>

    def setup_method(self, method):
        """Called at the beginning of each class method"""
>       self.net.restart_kytos_clean()

tests/test_e2e_60_of_multi_table.py:17:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/helpers.py:543: in restart_kytos_clean
    self.wait_kytos_links()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.helpers.NetworkTest object at 0x7f63ec0590d0>, a = None, b = None
port1 = None, port2 = None, status = None

    def wait_kytos_links(self, a=None, b=None, port1=None, port2=None, status=None):
        wait_count = 0
        last_error = ""
        topo_links = []
        links = self.net.links
        if a is not None:
            node_a = self.net.nameToNode.get(a)
            if not node_a:
                raise ValueError(f"Invalid node {a}")
            node_b = None
            if b is not None:
                node_b = self.net.nameToNode.get(b)
                if not node_b:
                    raise ValueError(f"Invalid node {b}")
            node_a_links = set()
            for intf in node_a.intfs.values():
                if not intf.link:
                    continue
                intf2 = intf.link.intf2 if intf.link.intf1 == intf else intf.link.intf1
                if node_b and intf2.node != node_b:
                    continue
                if any([
                    port1 is not None and not intf.name.endswith(f"eth{port1}"),
                    port2 is not None and not intf2.name.endswith(f"eth{port2}"),
                ]):
                    continue
                node_a_links.add(intf.link)
            links = list(node_a_links)
        for link in links:
            if link.intf1.node in self.net.switches and link.intf2.node in self.net.switches:
                link_id = self.create_link_id(link)
                if link_id:
                    topo_links.append(link_id)
        while wait_count < 60:
            try:
                response = requests.get("http://127.0.0.1:8181/api/kytos/topology/v3/links/", timeout=3)
                links = response.json()["links"]
                if a is not None:
                    links = {lid: links[lid] for lid in topo_links if lid in links}
                assert len(topo_links) == len(links), f"{topo_links=} {links=}"
                assert all(link_id in links for link_id in topo_links), f"{topo_links=} {links=}"
                if status is not None:
                    assert all(links[lid]["status"] == status for lid in topo_links), f"{topo_links} {links=} {status=}"
                break
            except Exception as exc:
                last_error = str(exc)
            time.sleep(1)
            wait_count += 1
        else:
            msg = f"Timeout waiting for links. Last error: {last_error}"
>           raise Exception(msg)
E           Exception: Timeout waiting for links. Last error: topo_links=['78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0', '4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30', 'c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07'] links={'78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0': {'id': '78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0', 'endpoint_a': {'id': '00:00:00:00:00:00:00:02:2', 'name': 's2-eth2', 'port_number': 2, 'mac': '4a:18:c4:76:df:49', 'switch': '00:00:00:00:00:00:00:02', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'lldp': True, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': [], 'link': '78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0'}, 'endpoint_b': {'id': '00:00:00:00:00:00:00:01:3', 'name': 's1-eth3', 'port_number': 3, 'mac': 'c2:21:9a:2b:9b:6d', 'switch': '00:00:00:00:00:00:00:01', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'lldp': True, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': [], 'link': '78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0'}, 'metadata': {}, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': []}, '4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30': {'id': '4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30', 'endpoint_a': {'id': '00:00:00:00:00:00:00:02:3', 'name': 's2-eth3', 'port_number': 3, 'mac': 'c2:d3:6c:5d:d2:42', 'switch': '00:00:00:00:00:00:00:02', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'lldp': True, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': [], 'link': '4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30'}, 'endpoint_b': {'id': '00:00:00:00:00:00:00:03:2', 'name': 's3-eth2', 'port_number': 2, 'mac': 'be:2e:b7:3a:d9:b1', 'switch': '00:00:00:00:00:00:00:03', 'type': 'interface', 'nni': True, 'uni': False, 'speed': 1250000000.0, 'metadata': {}, 'lldp': True, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': [], 'link': '4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30'}, 'metadata': {}, 'active': True, 'enabled': True, 'status': 'UP', 'status_reason': []}}

tests/helpers.py:496: Exception
=========================== rerun test summary info ============================
RERUN tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_035_create_evc_same_vid_different_uni
RERUN tests/test_e2e_11_mef_eline.py::TestE2EMefEline::test_005_on_primary_path_fail_should_migrate_to_backup
RERUN tests/test_e2e_31_of_lldp.py::TestE2EOfLLDP::test_002_disable_link_liveness
RERUN tests/test_e2e_60_of_multi_table.py::TestE2EOfMultiTable::test_020_invalid_pipelines
= 292 passed, 9 skipped, 2 xfailed, 1 xpassed, 4 rerun in 14417.41s (4:00:17) ==
```