### PR TITLE
Using condititonal import for P4OfSwitch and NoviSwitch

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,10 +14,14 @@ from collections import defaultdict
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
+HAS_NOVISWITCH = False
 if os.environ.get('SWITCH_CLASS') == "NoviSwitch":
     from tests.noviswitch import NoviSwitch
+    HAS_NOVISWITCH = True
+HAS_P4OFSWITCH = False
 if os.environ.get('SWITCH_CLASS') == "P4OfSwitch":
     from tests.p4ofswitch import P4OfSwitch
+    HAS_P4OFSWITCH = True
 
 BASE_ENV = os.environ.get('VIRTUAL_ENV', None) or '/'
 
@@ -588,9 +592,9 @@ class NetworkTest:
         # for NoviSwitch hosts, before changing the status of the veth interfaces
         # we need to actually change the status of the interface on the switch to
         # trigger the OpenFlow PortStatus message on Noviflow NOS
-        if isinstance(node_a, NoviSwitch):
+        if HAS_NOVISWITCH and isinstance(node_a, NoviSwitch):
             node_a.configLinkStatus([c[0] for c in connections], status)
-        if isinstance(node_b, NoviSwitch):
+        if HAS_NOVISWITCH and isinstance(node_b, NoviSwitch):
             node_b.configLinkStatus([c[1] for c in connections], status)
         # now we change the status on veth interfaces
         for srcIntf, dstIntf in connections:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,8 +14,10 @@ from collections import defaultdict
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
-from tests.noviswitch import NoviSwitch
-from tests.p4ofswitch import P4OfSwitch
+if os.environ.get('SWITCH_CLASS') == "NoviSwitch":
+    from tests.noviswitch import NoviSwitch
+if os.environ.get('SWITCH_CLASS') == "P4OfSwitch":
+    from tests.p4ofswitch import P4OfSwitch
 
 BASE_ENV = os.environ.get('VIRTUAL_ENV', None) or '/'
 
@@ -24,12 +26,14 @@ def dpctl_wrapper(obj, *args):
         return obj.orig_dpctl(*args, "--no-names", "--protocols=OpenFlow13", "|grep -v OFPST_FLOW")
     return obj.orig_dpctl(*args)
 
-NoviSwitch.orig_dpctl = NoviSwitch.dpctl
-NoviSwitch.dpctl = dpctl_wrapper
 OVSSwitch.orig_dpctl = OVSSwitch.dpctl
 OVSSwitch.dpctl = dpctl_wrapper
-P4OfSwitch.orig_dpctl = P4OfSwitch.dpctl
-P4OfSwitch.dpctl = dpctl_wrapper
+if os.environ.get('SWITCH_CLASS') == "NoviSwitch":
+    NoviSwitch.orig_dpctl = NoviSwitch.dpctl
+    NoviSwitch.dpctl = dpctl_wrapper
+if os.environ.get('SWITCH_CLASS') == "P4OfSwitch":
+    P4OfSwitch.orig_dpctl = P4OfSwitch.dpctl
+    P4OfSwitch.dpctl = dpctl_wrapper
 
 class SwitchFactory:
     def __new__(cls, *args, **kwargs):


### PR DESCRIPTION
Closes #446

### Summary

- Using conditional import to load p4ofswitch only when indeed using it as the switch class. The P4OfSwitch will require installing a customized version of Mininet that supports Docker nodes, as well as installing Docker daemon/containerd. To avoid this extra overhead when using simple OVS exec, the conditional imports seems a good approach.

### End-to-End Tests

results from gitlab-ci:

```
$ git checkout $END_TO_END_BRANCH
Switched to a new branch 'fix/p4ofswitch_noviswitch_cond_import'
branch 'fix/p4ofswitch_noviswitch_cond_import' set up to track 'origin/fix/p4ofswitch_noviswitch_cond_import'.
$ echo end-to-end repo branch $END_TO_END_BRANCH
end-to-end repo branch fix/p4ofswitch_noviswitch_cond_import
$ git log -1
commit 5f9c8683de1611601437909e5589d9296e74d473
Author: Italo Valcy <italovalcy@gmail.com>
Date:   Mon May 18 21:08:12 2026 -0300
    using a flag to check wheter NoviSwitch/P4OfSwitch is available
$ python3 ./scripts/gitlab_rs_init.py
Mapped hosts dict: {'mongo1': {'host': 'mongo1', 'port': '27017', 'host_port': 'mongo1:27017'}, 'mongo2': {'host': 'mongo2', 'port': '27018', 'host_port': 'mongo2:27018'}, 'mongo3': {'host': 'mongo3', 'port': '27019', 'host_port': 'mongo3:27019'}}
Running hello cmd on mongo1
{'topologyVersion': {'processId': ObjectId('6a0baae45ae680fee42d8ed7'), 'counter': 0}, 'isWritablePrimary': False, 'secondary': False, 'info': 'Does not have a valid replica set config', 'isreplicaset': True, 'maxBsonObjectSize': 16777216, 'maxMessageSizeBytes': 48000000, 'maxWriteBatchSize': 100000, 'localTime': datetime.datetime(2026, 5, 19, 0, 15, 6, 569000), 'logicalSessionTimeoutMinutes': 30, 'connectionId': 5, 'minWireVersion': 0, 'maxWireVersion': 21, 'readOnly': False, 'ok': 1.0}
Configuring replica set
Wrote mongo1:27017,mongo2:27018,mongo3:27019 to /tmp/host_seeds.txt
Waiting for node mongo1 to become primary
Waiting for the first node to be PRIMARY, current: None
Waiting for the first node to be PRIMARY, current: SECONDARY
Waiting for the first node to be PRIMARY, current: SECONDARY
Waiting for the first node to be PRIMARY, current: SECONDARY
Waiting for the first node to be PRIMARY, current: SECONDARY
First node stateStr is PRIMARY
Creating 'napps' user napp_user
$ export MONGO_HOST_SEEDS=$(cat /tmp/host_seeds.txt)
$ echo $MONGO_HOST_SEEDS
mongo1:27017,mongo2:27018,mongo3:27019
$ ./kytos-init.sh
+ '[' -z '' ']'
+ '[' -z '' ']'
+ echo 'There is no NAPPS_PATH specified. Default will be used.'
There is no NAPPS_PATH specified. Default will be used.
+ NAPPS_PATH=
+ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+ sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
+ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/TIMEOUT = 0.5/TIMEOUT = 3.0/g' /var/lib/kytos/napps/amlight/sdntrace/settings.py
+ kytosd --help
+ sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
+ grep -q aiokafka /etc/kytos/logging.ini
+ sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' /etc/kytos/logging.ini
+ echo -e '\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka'
+ test -z tests/
+ test -z ''
+ RERUNS=2
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 scripts/setup_kafka.py
Starting setup_kafka.py...
Attempting to create an admin client at ['broker1:9092', 'broker2:9092', 'broker3:9092']...
Admin client was successful! Attempting to validate cluster...
Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'broker1', 'port': 9092, 'rack': None}, {'node_id': 2, 'host': 'broker2', 'port': 9092, 'rack': None}, {'node_id': 3, 'host': 'broker3', 'port': 9092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 3}
Cluster was successfully validated! Attempting to create topic 'event_logs'...
Deleting topic event_logs...
Topic event_logs deleted, proceeding to creation.
Topic event_logs created successfully.
Topic 'event_logs' was created! Attempting to close the admin client...
Kafka admin client closed.
+ date
Tue May 19 00:15:26 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 303 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 28%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
tests/test_e2e_01_kytos_startup.py: 17 warnings
tests/test_e2e_05_topology.py: 17 warnings
tests/test_e2e_06_topology.py: 37 warnings
tests/test_e2e_08_topology.py: 18 warnings
tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_11_mef_eline.py: 25 warnings
tests/test_e2e_12_mef_eline.py: 17 warnings
tests/test_e2e_13_mef_eline.py: 17 warnings
tests/test_e2e_14_mef_eline.py: 76 warnings
tests/test_e2e_15_mef_eline.py: 17 warnings
tests/test_e2e_16_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
tests/test_e2e_18_mef_eline.py: 17 warnings
tests/test_e2e_20_flow_manager.py: 17 warnings
tests/test_e2e_21_flow_manager.py: 17 warnings
tests/test_e2e_22_flow_manager.py: 17 warnings
tests/test_e2e_23_flow_manager.py: 17 warnings
tests/test_e2e_30_of_lldp.py: 17 warnings
tests/test_e2e_31_of_lldp.py: 17 warnings
tests/test_e2e_32_of_lldp.py: 11 warnings
tests/test_e2e_40_sdntrace.py: 49 warnings
tests/test_e2e_41_kytos_auth.py: 17 warnings
tests/test_e2e_42_sdntrace.py: 84 warnings
tests/test_e2e_50_maintenance.py: 17 warnings
tests/test_e2e_60_of_multi_table.py: 17 warnings
tests/test_e2e_70_kytos_stats.py: 17 warnings
tests/test_e2e_80_pathfinder.py: 37 warnings
tests/test_e2e_90_kafka_events.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <
tests/test_e2e_01_kytos_startup.py: 17 warnings
tests/test_e2e_05_topology.py: 17 warnings
tests/test_e2e_06_topology.py: 37 warnings
tests/test_e2e_08_topology.py: 18 warnings
tests/test_e2e_10_mef_eline.py: 17 warnings
tests/test_e2e_11_mef_eline.py: 25 warnings
tests/test_e2e_12_mef_eline.py: 17 warnings
tests/test_e2e_13_mef_eline.py: 17 warnings
tests/test_e2e_14_mef_eline.py: 76 warnings
tests/test_e2e_15_mef_eline.py: 17 warnings
tests/test_e2e_16_mef_eline.py: 17 warnings
tests/test_e2e_17_mef_eline.py: 37 warnings
tests/test_e2e_18_mef_eline.py: 17 warnings
tests/test_e2e_20_flow_manager.py: 17 warnings
tests/test_e2e_21_flow_manager.py: 17 warnings
tests/test_e2e_22_flow_manager.py: 17 warnings
tests/test_e2e_23_flow_manager.py: 17 warnings
tests/test_e2e_30_of_lldp.py: 17 warnings
tests/test_e2e_31_of_lldp.py: 17 warnings
tests/test_e2e_32_of_lldp.py: 11 warnings
tests/test_e2e_40_sdntrace.py: 49 warnings
tests/test_e2e_41_kytos_auth.py: 17 warnings
tests/test_e2e_42_sdntrace.py: 84 warnings
tests/test_e2e_50_maintenance.py: 17 warnings
tests/test_e2e_60_of_multi_table.py: 17 warnings
tests/test_e2e_70_kytos_stats.py: 17 warnings
tests/test_e2e_80_pathfinder.py: 37 warnings
tests/test_e2e_90_kafka_events.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 291 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 14682.59s (4:04:42) =
```