### PR TITLE
fix: correct sysctl parameter to disable ipv6 router solicitation for hosts and switches

### DIFF
--- a/tests/test_e2e_08_topology.py
+++ b/tests/test_e2e_08_topology.py
@@ -27,7 +27,7 @@ class TestE2ETopologyDupDpid:
         cls.net.stop()
 
     @pytest.mark.skipif(
-        os.environ.get("SWITCH_CLASS") == "NoviSwitch",
+        os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
         reason="No need to repeat for NoviFlow",
     )
     def test_dup_dpid_does_not_overwrite_sw1_interfaces(self):

--- a/tests/test_e2e_08_topology.py
+++ b/tests/test_e2e_08_topology.py
@@ -28,7 +28,7 @@ class TestE2ETopologyDupDpid:
 
     @pytest.mark.skipif(
         os.environ.get("SWITCH_CLASS") in ("NoviSwitch", "P4OfSwitch"),
-        reason="No need to repeat for NoviFlow",
+        reason="No need to repeat for NoviFlow/P4OfSwitch",
     )
     def test_dup_dpid_does_not_overwrite_sw1_interfaces(self):
         """Test that a switch with a duplicate DPID connecting later does not

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -17,8 +17,10 @@ class TestE2EOfLLDP:
         cls.net.wait_switches_connect()
         # disable ipv6 router solicitation to avoid interfere with stats
         for host in cls.net.net.hosts:
-            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
+            host.cmd("echo 0 | tee /proc/sys/net/ipv6/conf/*/router_solicitations")
+        for sw in cls.net.net.switches:
+            for intf in sw.intfNames():
+                sw.cmd(f"echo 0 | tee /proc/sys/net/ipv6/conf/{intf}/router_solicitations")
         time.sleep(10)
 
     @classmethod

--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -22,8 +22,10 @@ class TestE2EKytosStats:
         cls.net.start(start_controller=False)
         # disable ipv6 router solicitation to avoid interfere with stats
         for host in cls.net.net.hosts:
-            host.cmd("sysctl net.ipv6.conf.all.accept_ra=0")
-            host.cmd("sysctl net.ipv6.conf.default.accept_ra=0")
+            host.cmd("echo 0 | tee /proc/sys/net/ipv6/conf/*/router_solicitations")
+        for sw in cls.net.net.switches:
+            for intf in sw.intfNames():
+                sw.cmd(f"echo 0 | tee /proc/sys/net/ipv6/conf/{intf}/router_solicitations")
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Closes #issue_number

### Summary

- This PR applies the correct sysctl parameter to stop ICMPv6 Router solicitation, on all interfaces and on hosts and switches. It was noticed that the sysctl parameter used to avoid ICMPv6 Router Solicitation had three problems: 1) the parameter was actually wrong (we were using `accept_ra` instead of `routers_solicitations`); 2) we were applying to group `all` and `default`, but it seems you also have to apply to each individual interface's  sysctl parameter; 3) we were applying to the host but not to the switch (other end of the veth tunnel), which would lead to some messages still being received and messing up with stats
- Adding pytest skip to avoid `test_dup_dpid_does_not_overwrite_sw1_interfaces` be executed on P4OfSwitch

### End-to-End Tests

exec on kubernetes with OVSSwitch:

```
+ date
Tue May 19 20:47:01 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 304 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

------------------------------- start/stop times -------------------------------
= 292 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 14584.85s (4:03:04) =
```

With P4OfSwitch (heads-up: the rerun below will be handled on Issue #449 ):

```
+ date
Tue May 19 20:40:08 UTC 2026
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 304 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_08_topology.py s                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py R...                                   [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

------------------------------- start/stop times -------------------------------
rerun: 0
tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows: 2026-05-20,00:08:23.172020 - 2026-05-20,00:09:17.998431
self = <tests.test_e2e_21_flow_manager.TestE2EFlowManager object at 0x7f67e6240510>

    def test_030_restart_kytos_should_preserve_flows(self):
        """Test if, after kytos restart, the flows are preserved on the switch
           flow table."""

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "match": {
                        "in_port": 1,
                        "dl_vlan": 999
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 202, response.text
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        wait_time = 20
        time.sleep(wait_time)

        # restart controller keeping configuration
        t1 = time.time()
        self.net.start_controller()
        self.net.wait_switches_connect()
        delta = time.time() - t1

        # wait for the flow to be installed
        time.sleep(wait_time)
        wait_time += wait_time

        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
        for flow in flows_s1.splitlines():
            # Check all flows but the of_lldp, which is reinstalled
            if 'dl_vlan=999' not in flow: continue
            match = re.search("duration=([0-9.]+)", flow)
            duration = float(match.group(1))
>           assert duration + 1 >= wait_time + delta
E           assert (53.0 + 1) >= (40 + 14.2364022731781)

tests/test_e2e_21_flow_manager.py:93: AssertionError
=========================== rerun test summary info ============================
RERUN tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows
= 290 passed, 11 skipped, 2 xfailed, 1 xpassed, 1 rerun in 21874.33s (6:04:34) =
```