### PR TITLE
Fix/issue 449 - improved installed flow duration calculation for test_030_restart_kytos_should_preserve_flows

### DIFF
--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -69,8 +69,19 @@ class TestE2EFlowManager:
         assert 'FlowMod Messages Sent' in data['response']
 
         # wait for the flow to be installed
-        wait_time = 20
-        time.sleep(wait_time)
+        time.sleep(10)
+
+        # make sure flow was installed and get initial time duration
+        s1 = self.net.net.get('s1')
+        assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
+        flows_s1 = s1.dpctl('dump-flows')
+        initial_duration = 0
+        for flow in flows_s1.splitlines():
+            match = re.search("duration=([0-9.]+).*dl_vlan=999", flow)
+            if match:
+                initial_duration = float(match.group(1))
+                break
+        assert initial_duration > 0, flows_s1
 
         # restart controller keeping configuration
         t1 = time.time()
@@ -78,19 +89,19 @@ class TestE2EFlowManager:
         self.net.wait_switches_connect()
         delta = time.time() - t1
 
-        # wait for the flow to be installed
-        time.sleep(wait_time)
-        wait_time += wait_time
+        # wait a few seconds to allow consistency check to run
+        time.sleep(20)
+        initial_duration += 20
 
-        s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
+        duration  = 0
         for flow in flows_s1.splitlines():
-            # Check all flows but the of_lldp, which is reinstalled
-            if 'dl_vlan=999' not in flow: continue
-            match = re.search("duration=([0-9.]+)", flow)
-            duration = float(match.group(1))
-            assert duration + 1 >= wait_time + delta
+            match = re.search("duration=([0-9.]+).*dl_vlan=999", flow)
+            if match:
+                duration = float(match.group(1))
+                break
+        assert duration > initial_duration + delta, flows_s1
 
     def test_031_on_switch_restart_kytos_should_recreate_flows(self):
         """Test if, after kytos restart, the flows are preserved on the switch 

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -73,6 +73,7 @@ class TestE2EFlowManager:
 
         # make sure flow was installed and get initial time duration
         s1 = self.net.net.get('s1')
+        flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.splitlines()) == BASIC_FLOWS + 1, flows_s1
         flows_s1 = s1.dpctl('dump-flows')
         initial_duration = 0

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -102,7 +102,7 @@ class TestE2EFlowManager:
             if match:
                 duration = float(match.group(1))
                 break
-        assert duration > initial_duration + delta, flows_s1
+        assert duration >= int(initial_duration + delta), flows_s1
 
     def test_031_on_switch_restart_kytos_should_recreate_flows(self):
         """Test if, after kytos restart, the flows are preserved on the switch 


### PR DESCRIPTION
Closes #449 

### Summary

- Improved logic on test `tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows ` to capture the initial flow installation time
 
### End-to-End Tests

Repeated this test 20 times with OVS and with P4OfSwitch and all of them passing without issues (before this PR, I was seeing errors after 10 execs more or less):

For OVS:

```
+ date
Wed May 20 14:53:38 UTC 2026
+ python3 -m pytest tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

tests/test_e2e_21_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================
tests/test_e2e_21_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_21_flow_manager.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 97.33s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-1.txt <==
================== 1 passed, 34 warnings in 97.53s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-10.txt <==
================== 1 passed, 34 warnings in 98.05s (0:01:38) ===================

==> /results-kytos-e2e-ovs-test21-11.txt <==
================== 1 passed, 34 warnings in 97.65s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-12.txt <==
================== 1 passed, 34 warnings in 102.53s (0:01:42) ==================

==> /results-kytos-e2e-ovs-test21-13.txt <==
================== 1 passed, 34 warnings in 102.31s (0:01:42) ==================

==> /results-kytos-e2e-ovs-test21-14.txt <==
================== 1 passed, 34 warnings in 97.94s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-15.txt <==
================== 1 passed, 34 warnings in 98.05s (0:01:38) ===================

==> /results-kytos-e2e-ovs-test21-16.txt <==
================== 1 passed, 34 warnings in 97.30s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-17.txt <==
================== 1 passed, 34 warnings in 103.07s (0:01:43) ==================

==> /results-kytos-e2e-ovs-test21-18.txt <==
================== 1 passed, 34 warnings in 98.10s (0:01:38) ===================

==> /results-kytos-e2e-ovs-test21-19.txt <==
================== 1 passed, 34 warnings in 97.92s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-2.txt <==
================== 1 passed, 34 warnings in 97.10s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-20.txt <==
================== 1 passed, 34 warnings in 97.67s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-3.txt <==
================== 1 passed, 34 warnings in 97.51s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-4.txt <==
================== 1 passed, 34 warnings in 97.92s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-5.txt <==
================== 1 passed, 34 warnings in 102.56s (0:01:42) ==================

==> /results-kytos-e2e-ovs-test21-6.txt <==
================== 1 passed, 34 warnings in 97.69s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-7.txt <==
================== 1 passed, 34 warnings in 97.84s (0:01:37) ===================

==> /results-kytos-e2e-ovs-test21-8.txt <==
================== 1 passed, 34 warnings in 102.63s (0:01:42) ==================

==> /results-kytos-e2e-ovs-test21-9.txt <==
================== 1 passed, 34 warnings in 97.33s (0:01:37) ===================
```

With P4OfSwitch:

```
+ date
Wed May 20 15:15:45 UTC 2026
+ python3 -m pytest tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

tests/test_e2e_21_flow_manager.py .                                      [100%]

------------------------------- start/stop times -------------------------------
======================== 1 passed in 248.39s (0:04:08) =========================

==> /results-kytos-e2e-p4ofsw-test21-1.txt <==
======================== 1 passed in 244.66s (0:04:04) =========================

==> /results-kytos-e2e-p4ofsw-test21-10.txt <==
======================== 1 passed in 256.71s (0:04:16) =========================

==> /results-kytos-e2e-p4ofsw-test21-11.txt <==
======================== 1 passed in 249.51s (0:04:09) =========================

==> /results-kytos-e2e-p4ofsw-test21-12.txt <==
======================== 1 passed in 245.09s (0:04:05) =========================

==> /results-kytos-e2e-p4ofsw-test21-13.txt <==
======================== 1 passed in 245.08s (0:04:05) =========================

==> /results-kytos-e2e-p4ofsw-test21-14.txt <==
======================== 1 passed in 245.20s (0:04:05) =========================

==> /results-kytos-e2e-p4ofsw-test21-15.txt <==
======================== 1 passed in 248.45s (0:04:08) =========================

==> /results-kytos-e2e-p4ofsw-test21-16.txt <==
======================== 1 passed in 246.16s (0:04:06) =========================

==> /results-kytos-e2e-p4ofsw-test21-17.txt <==
======================== 1 passed in 248.55s (0:04:08) =========================

==> /results-kytos-e2e-p4ofsw-test21-18.txt <==
======================== 1 passed in 250.96s (0:04:10) =========================

==> /results-kytos-e2e-p4ofsw-test21-19.txt <==
======================== 1 passed in 245.60s (0:04:05) =========================

==> /results-kytos-e2e-p4ofsw-test21-2.txt <==
======================== 1 passed in 251.05s (0:04:11) =========================

==> /results-kytos-e2e-p4ofsw-test21-20.txt <==
======================== 1 passed in 246.59s (0:04:06) =========================

==> /results-kytos-e2e-p4ofsw-test21-3.txt <==
======================== 1 passed in 248.11s (0:04:08) =========================

==> /results-kytos-e2e-p4ofsw-test21-4.txt <==
======================== 1 passed in 251.47s (0:04:11) =========================

==> /results-kytos-e2e-p4ofsw-test21-5.txt <==
======================== 1 passed in 259.08s (0:04:19) =========================

==> /results-kytos-e2e-p4ofsw-test21-6.txt <==
======================== 1 passed in 249.67s (0:04:09) =========================

==> /results-kytos-e2e-p4ofsw-test21-7.txt <==
======================== 1 passed in 250.58s (0:04:10) =========================

==> /results-kytos-e2e-p4ofsw-test21-8.txt <==
======================== 1 passed in 247.62s (0:04:07) =========================

==> /results-kytos-e2e-p4ofsw-test21-9.txt <==
======================== 1 passed in 248.39s (0:04:08) =========================
```