### PR TITLE
Refactor unnecessary Kytos restarts

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -32,8 +32,7 @@ class TestE2EKytosServer:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
+        cls.net.start(start_controller=False)
         # rotate logfile (copy/truncate strategy)
         try:
             cls.logfile = '/var/log/syslog'

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -24,9 +24,7 @@ class TestE2ETopology:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_06_topology.py
+++ b/tests/test_e2e_06_topology.py
@@ -24,9 +24,7 @@ class TestE2ETopology:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="multi")
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_08_topology.py
+++ b/tests/test_e2e_08_topology.py
@@ -19,8 +19,7 @@ class TestE2ETopologyDupDpid:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="ring")
-        cls.net.start()
-        cls.net.wait_switches_connect()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -41,10 +41,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -34,10 +34,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='ring4')
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -23,22 +23,19 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):
         cls.net.stop()
 
-    @pytest.fixture()
-    def kytos_clean(self):
+    def setup_method(self, method):
         self.net.restart_kytos_clean()
         self.net.wait_switches_connect()
         time.sleep(10)
 
     @pytest.fixture()
-    def circuit_id(self, kytos_clean):
+    def circuit_id(self):
         created_id = self._create_circuit()
         return created_id
 

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -32,10 +32,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_15_mef_eline.py
+++ b/tests/test_e2e_15_mef_eline.py
@@ -23,10 +23,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="ring")
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_16_mef_eline.py
+++ b/tests/test_e2e_16_mef_eline.py
@@ -23,10 +23,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="ring")
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_17_mef_eline.py
+++ b/tests/test_e2e_17_mef_eline.py
@@ -45,10 +45,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="multi")
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -16,10 +16,7 @@ class TestE2EMefEline:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="ring")
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -32,9 +32,7 @@ class TestE2EFlowManager:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -31,9 +31,7 @@ class TestE2EFlowManager:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_22_flow_manager.py
+++ b/tests/test_e2e_22_flow_manager.py
@@ -23,9 +23,7 @@ class TestE2EFlowManager:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_23_flow_manager.py
+++ b/tests/test_e2e_23_flow_manager.py
@@ -31,9 +31,7 @@ class TestE2EFlowManager:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -12,7 +12,7 @@ class TestE2EOfLLDP:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
+        cls.net.start(start_controller=False)
         cls.net.restart_kytos_clean()
         cls.net.wait_switches_connect()
         # disable ipv6 router solicitation to avoid interfere with stats

--- a/tests/test_e2e_31_of_lldp.py
+++ b/tests/test_e2e_31_of_lldp.py
@@ -19,9 +19,7 @@ class TestE2EOfLLDP:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_32_of_lldp.py
+++ b/tests/test_e2e_32_of_lldp.py
@@ -12,7 +12,7 @@ class TestE2EOfLLDPLoopDetection:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='looped')
-        cls.net.start()
+        cls.net.start(start_controller=False)
         cls.net.restart_kytos_clean()
         time.sleep(10)
 

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -14,9 +14,7 @@ class TestE2ESDNTrace:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='linear10')
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_41_kytos_auth.py
+++ b/tests/test_e2e_41_kytos_auth.py
@@ -37,7 +37,7 @@ class TestE2EKytosAuth:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_42_sdntrace.py
+++ b/tests/test_e2e_42_sdntrace.py
@@ -13,9 +13,7 @@ class TestE2ESDNTrace:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='amlight_looped')
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_50_maintenance.py
+++ b/tests/test_e2e_50_maintenance.py
@@ -24,7 +24,7 @@ class TestE2EMaintenance:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="ring")
-        cls.net.start()
+        cls.net.start(start_controller=False)
         cls.net.restart_kytos_clean()
         cls.net.wait_switches_connect()
         time.sleep(10)

--- a/tests/test_e2e_60_of_multi_table.py
+++ b/tests/test_e2e_60_of_multi_table.py
@@ -20,9 +20,7 @@ class TestE2EOfMultiTable:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        time.sleep(10)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_80_pathfinder.py
+++ b/tests/test_e2e_80_pathfinder.py
@@ -25,10 +25,7 @@ class TestE2EPathfinder:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name="multi")
-        cls.net.start()
-        cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(5)
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_90_kafka_events.py
+++ b/tests/test_e2e_90_kafka_events.py
@@ -34,8 +34,7 @@ class TestE2EKafkaEvents:
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
-        cls.net.start()
-        cls.net.wait_switches_connect()
+        cls.net.start(start_controller=False)
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Closes #451

### Summary

- refactoring kytos restarts on setup_class and also on setup_method, which led to sometime up to 3 restarts


### End-to-End Tests

Please see the results here: https://github.com/kytos-ng/of_lldp/pull/131#issuecomment-4525026682