### PR TITLE
adding tolerance for float number comparison for kytos stats

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -273,11 +273,12 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
+        tolerance = 0.01
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['packet_count']
             assert info_flow['packet_counter'] >= count
-            assert info_flow['packet_per_second'] >= count/data_flow[flow_id]['duration_sec']
+            assert info_flow['packet_per_second'] + tolerance >= count/data_flow[flow_id]['duration_sec']
 
 
     def test_030_bytes_count_per_flow(self):


### PR DESCRIPTION
Closes #453 

### Summary

- Added tolerance for float number comparison for Kytos stats packet/sec metric

### End-to-End Tests

Repeated the same test 30 times and no surprises observed:

```
# python3 -m pytest tests/ -k test_025_packet_count_per_flow  --reruns 0 --count 30 -r fEr 

============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: timeout-2.2.0, asyncio-1.1.0, rerunfailures-13.0, anyio-4.3.0, repeat-0.9.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9120 items / 9090 deselected / 30 selected

tests/test_e2e_70_kytos_stats.py ..............................          [100%]

=============================== warnings summary ===============================
tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

tests/test_e2e_70_kytos_stats.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
======== 30 passed, 9090 deselected, 34 warnings in 1059.24s (0:17:39) =========
```