### PR TITLE
Added test for intra EVC

### DIFF
--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -84,6 +84,17 @@ class TestE2EMefEline:
         assert response.status_code == 200, response.text
 
         return
+    
+    def get_mef_eline_flow_number(self):
+        api_url = KYTOS_API + '/flow_manager/v2/stored_flows?state=installed'
+        response = requests.get(api_url)
+        flows = response.json()
+        total_flows_prev = 0
+        for _, flow_list in flows.items():
+            for flow in flow_list:
+                if flow["flow"]["owner"] == "mef_eline":
+                    total_flows_prev += 1
+        return total_flows_prev
 
     def test_create_schedule_by_frequency(self, disabled_circuit_id):
         """ Test scheduler creation to enable the circuit by frequency, 
@@ -384,3 +395,56 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.patch(api_url, json=payload)
         assert response.status_code == 404, response.text
+
+    def test_intra_evc_uni_enabled(self):
+        """ Test if the UNI of an intra-EVC circuit is enabled. """
+        api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/disable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+
+        circuit_id = self._create_circuit()
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data['enabled'] is True
+        
+        assert self.get_mef_eline_flow_number() == 0
+
+        api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/enable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+        for i in [1, 2]:
+            api_url = KYTOS_API + f'/topology/v3/interfaces/00:00:00:00:00:00:00:01:{i}/enable'
+            response = requests.post(api_url)
+            assert response.status_code == 200, response.text
+        time.sleep(10)
+        assert self.get_mef_eline_flow_number() == 2
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        response = requests.patch(api_url, json={"enabled": False})
+        assert response.status_code == 200, response.text
+
+        assert self.get_mef_eline_flow_number() == 0
+
+        api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/disable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        response = requests.patch(api_url, json={"enabled": True})
+        assert response.status_code == 200, response.text
+
+        assert self.get_mef_eline_flow_number() == 0
+
+        api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/enable'
+        response = requests.post(api_url)
+        assert response.status_code == 201, response.text
+        for i in [1, 2]:
+            api_url = KYTOS_API + f'/topology/v3/interfaces/00:00:00:00:00:00:00:01:{i}/enable'
+            response = requests.post(api_url)
+            assert response.status_code == 200, response.text
+
+        time.sleep(10)
+        assert self.get_mef_eline_flow_number() == 2

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -86,11 +86,11 @@ class TestE2EMefEline:
         return
     
     def get_mef_eline_flow_number(self, circuit_id=None):
-        mask = "ffffffffffffff"
+        masks = ['ffffffffffffff', '00000000000000']
         if circuit_id is not None:
-            mask = circuit_id
-        cookie = int(f"0xaa{mask}", 16)
-        api_url = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}&state=installed'
+            masks = [circuit_id, circuit_id]
+        cookies = [int(f"0xaa{mask}", 16) for mask in masks]
+        api_url = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookies[0]}&cookie_range={cookies[1]}&state=installed'
         response = requests.get(api_url)
         flows = response.json()
         total_flows_prev = 0

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -85,15 +85,17 @@ class TestE2EMefEline:
 
         return
     
-    def get_mef_eline_flow_number(self):
-        api_url = KYTOS_API + '/flow_manager/v2/stored_flows?state=installed'
+    def get_mef_eline_flow_number(self, circuit_id=None):
+        mask = "ffffffffffffff"
+        if circuit_id is not None:
+            mask = circuit_id
+        cookie = int(f"0xaa{mask}", 16)
+        api_url = f'{KYTOS_API}/flow_manager/v2/stored_flows/?cookie_range={cookie}&cookie_range={cookie}&state=installed'
         response = requests.get(api_url)
         flows = response.json()
         total_flows_prev = 0
-        for _, flow_list in flows.items():
-            for flow in flow_list:
-                if flow["flow"]["owner"] == "mef_eline":
-                    total_flows_prev += 1
+        for flow_list in flows.values():
+            total_flows_prev += len(flow_list)
         return total_flows_prev
 
     def test_create_schedule_by_frequency(self, disabled_circuit_id):
@@ -410,7 +412,7 @@ class TestE2EMefEline:
         data = response.json()
         assert data['enabled'] is True
         
-        assert self.get_mef_eline_flow_number() == 0
+        assert self.get_mef_eline_flow_number(circuit_id) == 0
 
         api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/enable'
         response = requests.post(api_url)
@@ -420,13 +422,13 @@ class TestE2EMefEline:
             response = requests.post(api_url)
             assert response.status_code == 200, response.text
         time.sleep(10)
-        assert self.get_mef_eline_flow_number() == 2
+        assert self.get_mef_eline_flow_number(circuit_id) == 2
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.patch(api_url, json={"enabled": False})
         assert response.status_code == 200, response.text
 
-        assert self.get_mef_eline_flow_number() == 0
+        assert self.get_mef_eline_flow_number(circuit_id) == 0
 
         api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/disable'
         response = requests.post(api_url)
@@ -436,7 +438,7 @@ class TestE2EMefEline:
         response = requests.patch(api_url, json={"enabled": True})
         assert response.status_code == 200, response.text
 
-        assert self.get_mef_eline_flow_number() == 0
+        assert self.get_mef_eline_flow_number(circuit_id) == 0
 
         api_url = KYTOS_API + f'/topology/v3/switches/00:00:00:00:00:00:00:01/enable'
         response = requests.post(api_url)
@@ -447,4 +449,4 @@ class TestE2EMefEline:
             assert response.status_code == 200, response.text
 
         time.sleep(10)
-        assert self.get_mef_eline_flow_number() == 2
+        assert self.get_mef_eline_flow_number(circuit_id) == 2

--- a/tests/test_e2e_18_mef_eline.py
+++ b/tests/test_e2e_18_mef_eline.py
@@ -34,6 +34,19 @@ class TestE2EMefEline:
                 "up"
             )
 
+    def get_mef_eline_flow_number(self, circuit_id=None):
+        masks = ['ffffffffffffff', '00000000000000']
+        if circuit_id is not None:
+            masks = [circuit_id, circuit_id]
+        cookies = [int(f"0xaa{mask}", 16) for mask in masks]
+        api_url = f'{KYTOS_API}/kytos/flow_manager/v2/stored_flows/?cookie_range={cookies[0]}&cookie_range={cookies[1]}&state=installed'
+        response = requests.get(api_url)
+        flows = response.json()
+        total_flows_prev = 0
+        for flow_list in flows.values():
+            total_flows_prev += len(flow_list)
+        return total_flows_prev
+
     def assert_tag_used_by_interface(self, interface_id, tag_type, value):
         api_url = KYTOS_API + "/kytos/topology/v3/interfaces/tag_ranges"
         response = requests.get(api_url)
@@ -355,7 +368,10 @@ class TestE2EMefEline:
         assert not data["active"]
         assert data['current_path']
 
-    def test_060_patch_intra_to_inter_evc(self):
+    def test_060_patch_intra_to_inter_evc_1_uni(self):
+        """Test patching an intra-EVC to an inter-EVC by
+        changing only 1 UNI
+        """
         payload = {
             "name": "Test EVC",
             "uni_a": {
@@ -381,14 +397,8 @@ class TestE2EMefEline:
         data = response.json()
         evc_id = data["circuit_id"]
         time.sleep(10)
-        api_url = KYTOS_API + '/kytos/flow_manager/v2/stored_flows?state=installed'
-        response = requests.get(api_url)
-        flows = response.json()
-        total_flows_prev = 0
-        for _, flow_list in flows.items():
-            for flow in flow_list:
-                if flow["flow"]["owner"] == "mef_eline":
-                    total_flows_prev += 1
+
+        total_flows_prev = self.get_mef_eline_flow_number(evc_id)
         assert total_flows_prev == 2
 
         # Try to patch to new uni_z
@@ -424,13 +434,82 @@ class TestE2EMefEline:
         data = response.json()
         assert data["uni_z"]["interface_id"] != "00:00:00:00:00:00:00:01:2"
 
-        api_url = KYTOS_API + '/kytos/flow_manager/v2/stored_flows?state=installed'
-        response = requests.get(api_url)
-        flows = response.json()
-        total_flows_later = 0
-        for _, flow_list in flows.items():
-            for flow in flow_list:
-                if flow["flow"]["owner"] == "mef_eline":
-                    total_flows_later += 1
+        total_flows_later = self.get_mef_eline_flow_number(evc_id)
+        assert total_flows_later == 8
 
+    def test_070_patch_intra_to_inter_evc_2_unis(self):
+        """Test patching an intra-EVC to an inter-EVC by
+        changing only 2 UNI
+        """
+        payload = {
+            "name": "Test EVC",
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                },
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:01:2",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                },
+            },
+            "enabled": True,
+            "dynamic_backup_path": True,
+        }
+        api_url = KYTOS_API + "/kytos/mef_eline/v2/evc/"
+        response = requests.post(api_url, json=payload)
+        assert response.status_code == 201, response.text
+        data = response.json()
+        evc_id = data["circuit_id"]
+        time.sleep(10)
+
+        total_flows_prev = self.get_mef_eline_flow_number(evc_id)
+        assert total_flows_prev == 2
+
+        # Try to patch to new uni_z and uni_a
+        payload = {
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                }
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {
+                    "tag_type": "vlan",
+                    "value": 100,
+                }
+            }
+        }
+        api_url = KYTOS_API + f"/kytos/mef_eline/v2/evc/{evc_id}"
+        response = requests.patch(api_url, json=payload)
+        assert response.status_code == 200, response.text
+        time.sleep(10)
+
+        # Check old UNIs' tags
+        self.assert_tag_not_used_by_interface(
+            "00:00:00:00:00:00:00:01:1",
+            "vlan",
+            100
+        )
+        self.assert_tag_used_by_interface(
+            "00:00:00:00:00:00:00:03:1",
+            "vlan",
+            100
+        )
+
+        api_url = KYTOS_API + f"/kytos/mef_eline/v2/evc/{evc_id}"
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["uni_a"]["interface_id"] != "00:00:00:00:00:00:00:01:1"
+        assert data["uni_z"]["interface_id"] != "00:00:00:00:00:00:00:01:2"
+
+        total_flows_later = self.get_mef_eline_flow_number(evc_id)
         assert total_flows_later == 8


### PR DESCRIPTION
Closes #456

### Summary

Added the same tests as described in this [PR](https://github.com/kytos-ng/mef_eline/pull/721/) local test
Dependency from this [PR](https://github.com/kytos-ng/mef_eline/pull/721/)

### Local Tests

### End-to-End Tests
```
+ python3 -m pytest tests/ -k 'test_intra_evc_uni_enabled or test_060_patch_intra_to_inter_evc_1_uni or test_070_patch_intra_to_inter_evc_2_unis' --reruns 0 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: timeout-2.2.0, rerunfailures-13.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items / 306 deselected / 3 selected

tests/test_e2e_12_mef_eline.py .                                         [ 33%]
tests/test_e2e_18_mef_eline.py ..                                        [100%]
```
Running the rest