### PR TITLE
Allow for using host docker for P4OfSwitch

### DIFF
--- a/docker-compose.p4.yml
+++ b/docker-compose.p4.yml
@@ -1,0 +1,139 @@
+services:
+  kytos:
+    image: amlight/kytos:latest
+    privileged: true
+    volumes:
+      - "./kytos-init.sh:/kytos-init.sh"
+      - "./tests:/tests"
+      - "./scripts/wait_for_mongo.py:/scripts/wait_for_mongo.py"
+      - "./scripts/setup_kafka.py:/scripts/setup_kafka.py"
+      - "./pytest.ini:/pytest.ini"
+      - "./kytos.log:/kytos.log"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/usr/bin/docker:/usr/bin/docker"
+    command:
+      - /kytos-init.sh
+    environment:
+      MONGO_USERNAME: napp_user
+      MONGO_PASSWORD: napp_pw
+      MONGO_DBNAME: napps
+      MONGO_HOST_SEEDS: "mongo1t:27027,mongo2t:27028,mongo3t:27029"
+      KAFKA_HOST_ADDR: "broker1:19092,broker2:19092,broker3:19092"
+      SWITCH_CLASS: P4OfSwitch
+      MININET_DOCKER_NETWORK: ${COMPOSE_PROJECT_NAME}_mininet
+    depends_on:
+      - mongo-setup
+      - broker1
+      - broker2
+      - broker3
+    pid: host
+    networks:
+     - mininet-network
+     - default
+  broker1:
+    image: apache/kafka:4.0.0
+    container_name: broker1
+    restart: unless-stopped
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:19092,CONTROLLER://:9093,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker1:19092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker1:9093,2@broker2:9093,3@broker3:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  broker2:
+    image: apache/kafka:4.0.0
+    container_name: broker2
+    restart: unless-stopped
+    ports:
+      - 19092:9092
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:19092,CONTROLLER://:9093,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker2:19092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker1:9093,2@broker2:9093,3@broker3:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  broker3:
+    image: apache/kafka:4.0.0
+    container_name: broker3
+    restart: unless-stopped
+    ports:
+      - 29092:9092
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:19092,CONTROLLER://:9093,PLAINTEXT_HOST://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker3:19092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker1:9093,2@broker2:9093,3@broker3:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  mongo-setup:
+    container_name: mongo-test-rs-init
+    image: mongo:7.0
+    restart: on-failure
+    volumes:
+      - ./scripts:/scripts
+    entrypoint: ["/scripts/rs-init.sh"]
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root_user
+      MONGO_INITDB_ROOT_PASSWORD: root_pw
+      MONGO_USERNAME: napp_user
+      MONGO_PASSWORD: napp_pw
+      MONGO_DBNAME: napps
+      MONGO_NODES: mongo1t:27027 mongo2t:27028 mongo3t:27029
+    depends_on:
+      - mongo1t
+      - mongo2t
+      - mongo3t
+  mongo1t:
+    container_name: mongo1t
+    image: mongo:7.0
+    ports:
+      - 27027:27027
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27027" ]
+    depends_on:
+      - mongo2t
+      - mongo3t
+  mongo2t:
+    container_name: mongo2t
+    image: mongo:7.0
+    ports:
+      - 27028:27028
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27028" ]
+  mongo3t:
+    container_name: mongo3t
+    image: mongo:7.0
+    ports:
+      - 27029:27029
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27029" ]
+networks:
+  mininet-network:
+    name: ${COMPOSE_PROJECT_NAME}_mininet
+  
+#  mininet:
+#      image: italovalcy/mininet:latest
+#      privileged: true
+#      links:
+#        - "kytos"
+#      command:
+#        - /usr/bin/tail -f /dev/null

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,6 +22,7 @@ HAS_P4OFSWITCH = False
 if os.environ.get('SWITCH_CLASS') == "P4OfSwitch":
     from tests.p4ofswitch import P4OfSwitch
     HAS_P4OFSWITCH = True
+DOCKER_NETWORK = os.environ.get("MININET_DOCKER_NETWORK")
 
 BASE_ENV = os.environ.get('VIRTUAL_ENV', None) or '/'
 
@@ -45,7 +46,7 @@ class SwitchFactory:
         if cls_name == "NoviSwitch" and NoviSwitch.is_available():
             return NoviSwitch(*args, **kwargs)
         if cls_name == "P4OfSwitch":
-            return P4OfSwitch(*args, **kwargs)
+            return P4OfSwitch(*args, docker_network=DOCKER_NETWORK, **kwargs)
         return OVSSwitch(*args, **kwargs)
 
 

--- a/tests/p4ofswitch.py
+++ b/tests/p4ofswitch.py
@@ -1,17 +1,34 @@
 """P4OfSwitch"""
 
+import json
 import os
 import re
+import subprocess
 import time
 from mininet.nodelib import DockerSwitch
 from mininet.log import error, info
 from mininet.util import quietRun
 
+
 P4OFSWITCH_ARCH = os.environ.get("P4OFSWITCH_ARCH", "tf1")
 
 P4OFSWITCH_IMAGE = os.environ.get("P4OFSWITCH_IMAGE", "amlight/p4ofswitch:latest")
 
+DOCKER_NETWORK = os.environ.get("MININET_DOCKER_NETWORK")
+
 MYLOCALIP = os.environ.get("MYLOCALIP")
+
+if os.environ.get("SWITCH_CLASS") == "P4OfSwitch" and not MYLOCALIP and DOCKER_NETWORK:
+    with open("/etc/hostname") as hostname_file:
+        cid = hostname_file.read().strip()
+    data = json.loads(
+        subprocess.check_output(
+            ["docker", "inspect", cid],
+            text=True
+        )
+    )
+    MYLOCALIP = data[0]["NetworkSettings"]["Networks"][DOCKER_NETWORK]["IPAddress"]
+
 if os.environ.get("SWITCH_CLASS") == "P4OfSwitch" and not MYLOCALIP:
     try:
         stream = os.popen("ip -j route get 8.8.8.8 | jq -r '.[0].prefsrc'")


### PR DESCRIPTION
### Summary

Requires building the kytos docker image to use the mininet from italovalcy/mininet#2

### End-to-End Tests

Ran out of memory. My system only has 32GB. Also I only realized after the fact that I was running kytos with separate tag pools with the unmodified tests, so tests that should have passed were failing.

```
kytos-1  | [WARN  tini (331181)] Tini is not running as PID 1 and isn't registered as a child subreaper.
kytos-1  | Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
kytos-1  | To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
kytos-1  | Starting enhanced syslogd: rsyslogd.
kytos-1  | /etc/openvswitch/conf.db does not exist ... (warning).
kytos-1  | Creating empty database /etc/openvswitch/conf.db.
kytos-1  | Starting ovsdb-server.
kytos-1  | Configuring Open vSwitch system IDs.
kytos-1  | Starting ovs-vswitchd.
kytos-1  | Enabling remote OVSDB managers.
kytos-1  | + '[' -z '' ']'
kytos-1  | + '[' -z '' ']'
kytos-1  | + echo 'There is no NAPPS_PATH specified. Default will be used.'
kytos-1  | + NAPPS_PATH=
kytos-1  | + sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
kytos-1  | There is no NAPPS_PATH specified. Default will be used.
kytos-1  | + sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 14/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
kytos-1  | + sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
kytos-1  | + sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
kytos-1  | + sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
kytos-1  | + sed -i 's/TIMEOUT = 0.5/TIMEOUT = 3.0/g' /var/lib/kytos/napps/amlight/sdntrace/settings.py
kytos-1  | + kytosd --help
kytos-1  | + sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
kytos-1  | + grep -q aiokafka /etc/kytos/logging.ini
kytos-1  | + sed -i 's/keys: root,kytos,api_server,socket/keys: root,kytos,api_server,socket,aiokafka/' /etc/kytos/logging.ini
kytos-1  | + echo -e '\n\n[logger_aiokafka]\nlevel: INFO\nhandlers:\nqualname: aiokafka'
kytos-1  | + test -z ''
kytos-1  | + TESTS=tests/
kytos-1  | + test -z ''
kytos-1  | + RERUNS=2
kytos-1  | + python3 scripts/wait_for_mongo.py
kytos-1  | Trying to run hello command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Trying to run 'hello' command on MongoDB...
kytos-1  | Ran 'hello' command on MongoDB successfully. It's ready!
kytos-1  | + python3 scripts/setup_kafka.py
kytos-1  | Starting setup_kafka.py...
kytos-1  | Attempting to create an admin client at ['broker1:19092', 'broker2:19092', 'broker3:19092']...
kytos-1  | Admin client was successful! Attempting to validate cluster...
kytos-1  | Cluster info: {'throttle_time_ms': 0, 'brokers': [{'node_id': 1, 'host': 'broker1', 'port': 19092, 'rack': None}, {'node_id': 2, 'host': 'broker2', 'port': 19092, 'rack': None}, {'node_id': 3, 'host': 'broker3', 'port': 19092, 'rack': None}], 'cluster_id': '5L6g3nShT-eMCtK--X86sw', 'controller_id': 2}
kytos-1  | Cluster was successfully validated! Attempting to create topic 'event_logs'...
kytos-1  | Deleting topic event_logs...
kytos-1  | Topic event_logs deleted, proceeding to creation.
kytos-1  | Topic event_logs created successfully.
kytos-1  | Topic 'event_logs' was created! Attempting to close the admin client...
kytos-1  | Kafka admin client closed.
kytos-1  | + date
kytos-1  | Thu Jun  4 19:09:29 UTC 2026
kytos-1  | + python3 -m pytest tests/ --reruns 2 -r fEr
kytos-1  | ============================= test session starts ==============================
kytos-1  | platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
kytos-1  | rootdir: /
kytos-1  | configfile: pytest.ini
kytos-1  | plugins: rerunfailures-13.0, timeout-2.2.0, asyncio-1.1.0, anyio-4.3.0
kytos-1  | asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
kytos-1  | collected 306 items
kytos-1  | 
kytos-1  | tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
kytos-1  | tests/test_e2e_05_topology.py ...................                        [  6%]
kytos-1  | tests/test_e2e_06_topology.py s..s.                                      [  8%]
kytos-1  | tests/test_e2e_08_topology.py s                                          [  8%]
kytos-1  | tests/test_e2e_10_mef_eline.py ..........ss.....x.....................RR [ 21%]
kytos-1  | F..                                                                      [ 22%]
kytos-1  | tests/test_e2e_11_mef_eline.py .......RRF                                [ 25%]
kytos-1  | tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
kytos-1  | tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
kytos-1  | .                                                                        [ 41%]
```