### PR TITLE
fix: increase tolerate time to 0.1 on test_025_packet_count_per_flow

### DIFF
--- a/tests/test_e2e_70_kytos_stats.py
+++ b/tests/test_e2e_70_kytos_stats.py
@@ -273,7 +273,7 @@ class TestE2EKytosStats:
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        tolerance = 0.01
+        tolerance = 0.1
         for info_flow in data:
             flow_id = info_flow['flow_id']
             count = data_flow[flow_id]['packet_count']


### PR DESCRIPTION
Closes #462

### Summary

- Increased toleration time for `test_025_packet_count_per_flow ` to avoid RERUNs

### End-to-End Tests

I think we dont need a full exec on this just to validate this feature. I think the time and normal daily execs will demonstrate its effectiveness.