### PR TITLE
Fix duplicate volumeMounts in Kubernetes YAML

### DIFF
--- a/misc/kubernetes-kytos-mongo-kafka.yaml
+++ b/misc/kubernetes-kytos-mongo-kafka.yaml
@@ -46,7 +46,6 @@ spec:
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
-        volumeMounts:
         - name: docker-storage
           mountPath: /var/lib/docker
       - name: mongo1


### PR DESCRIPTION
Removed duplicate volumeMounts entry for docker-storage.

### Summary

Fixes /lib/modules not beeing mounted